### PR TITLE
Fix generated catalog metadata

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Regenerate catalog
         run: python3 scripts/generate_examples.py
 
+      - name: Validate generated metadata
+        run: python3 scripts/validate_metadata.py
+
       - name: Regenerate health report
         run: python3 scripts/generate_catalog_health.py
 

--- a/scripts/generate_examples.py
+++ b/scripts/generate_examples.py
@@ -322,7 +322,7 @@ def build_json_ld(entries: list[dict[str, str | None]]) -> str:
             },
         ],
     }
-    return json.dumps(graph, ensure_ascii=False, separators=(",", ":"))
+    return json.dumps(graph, ensure_ascii=False, separators=(",", ":")).replace("<", "\\u003c")
 
 
 def update_static_metadata(entries: list[dict[str, str | None]]) -> None:

--- a/scripts/validate_metadata.py
+++ b/scripts/validate_metadata.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Validate generated catalog metadata against docs/examples.json."""
+
+from __future__ import annotations
+
+import json
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SITE_URL = "https://majiayu000.github.io/awesome-goal-prompts/"
+
+
+class IndexMetadataParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.meta: dict[str, str] = {}
+        self.json_ld_scripts: list[str] = []
+        self._capturing_json_ld = False
+        self._script_chunks: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        if tag == "meta":
+            key = attributes.get("property") or attributes.get("name")
+            content = attributes.get("content")
+            if key and content is not None:
+                self.meta[key] = content
+        if tag == "script" and attributes.get("type") == "application/ld+json":
+            self._capturing_json_ld = True
+            self._script_chunks = []
+
+    def handle_data(self, data: str) -> None:
+        if self._capturing_json_ld:
+            self._script_chunks.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "script" and self._capturing_json_ld:
+            self.json_ld_scripts.append("".join(self._script_chunks).strip())
+            self._capturing_json_ld = False
+            self._script_chunks = []
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def assert_equal(label: str, actual: object, expected: object) -> None:
+    if actual != expected:
+        fail(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def find_graph_node(graph: list[Any], node_type: str) -> dict[str, Any]:
+    for node in graph:
+        if isinstance(node, dict) and node.get("@type") == node_type:
+            return node
+    fail(f"JSON-LD missing {node_type} node")
+
+
+def main() -> None:
+    entries = json.loads((ROOT / "docs" / "examples.json").read_text(encoding="utf-8"))
+    if not isinstance(entries, list):
+        fail("docs/examples.json must contain a list")
+
+    source_entries = [entry for entry in entries if entry.get("origin") == "source-backed"]
+    source_count = len(source_entries)
+    seed_count = len(entries) - source_count
+
+    parser = IndexMetadataParser()
+    parser.feed((ROOT / "docs" / "index.html").read_text(encoding="utf-8"))
+
+    description = (
+        f"{source_count} source-backed /goal contracts for coding agents, "
+        f"plus {seed_count} reusable seed patterns in the extended library."
+    )
+    short_description = f"{source_count} source-backed /goal contracts for coding agents."
+    image_alt = f"The Contract Codex - {source_count} source-backed goal contracts for coding agents."
+
+    assert_equal("og:description", parser.meta.get("og:description"), description)
+    assert_equal("twitter:description", parser.meta.get("twitter:description"), short_description)
+    assert_equal("og:image:alt", parser.meta.get("og:image:alt"), image_alt)
+    assert_equal("twitter:image:alt", parser.meta.get("twitter:image:alt"), image_alt)
+
+    assert_equal("JSON-LD script count", len(parser.json_ld_scripts), 1)
+    payload = json.loads(parser.json_ld_scripts[0])
+    graph = payload.get("@graph")
+    if not isinstance(graph, list):
+        fail("JSON-LD @graph must be a list")
+
+    dataset = find_graph_node(graph, "Dataset")
+    item_list = find_graph_node(graph, "ItemList")
+    dataset_description = (
+        f"{source_count} source-backed /goal task contracts for coding agents, "
+        f"plus {seed_count} reusable seed patterns in the extended library."
+    )
+    assert_equal("Dataset description", dataset.get("description"), dataset_description)
+    assert_equal("ItemList numberOfItems", item_list.get("numberOfItems"), source_count)
+    assert_equal(
+        "ItemList description",
+        item_list.get("description"),
+        f"{source_count} source-backed task contracts in the primary catalog.",
+    )
+
+    items = item_list.get("itemListElement")
+    if not isinstance(items, list):
+        fail("ItemList itemListElement must be a list")
+    assert_equal("ItemList item count", len(items), source_count)
+
+    for position, (entry, item) in enumerate(zip(source_entries, items), start=1):
+        if not isinstance(item, dict):
+            fail(f"ItemList item {position} must be an object")
+        assert_equal(f"ItemList item {position} position", item.get("position"), position)
+        assert_equal(f"ItemList item {position} url", item.get("url"), f"{SITE_URL}#{entry['slug']}")
+        assert_equal(f"ItemList item {position} name", item.get("name"), entry.get("title"))
+        assert_equal(f"ItemList item {position} description", item.get("description"), entry.get("intent"))
+
+    print(f"metadata validation ok ({source_count} source-backed, {seed_count} seed patterns)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Fixes majiayu000/awesome-goal-prompts#4.
- Extends `scripts/generate_examples.py` so `docs/index.html` Open Graph/Twitter metadata and JSON-LD ItemList are derived from the loaded catalog entries.
- Regenerates `docs/index.html` to publish 303 catalog entries, 103 source-backed entries, and 303 JSON-LD list items.

## Example Type

- [ ] Source-backed example
- [ ] Seed/catalog example
- [x] Documentation or tooling change

## Source Evidence

For source-backed examples, add the public URL here:

- Source name: N/A
- Source URL: N/A
- Source type: N/A
- Evidence phrase: N/A
- Evidence summary generated by `python3 scripts/generate_examples.py`: N/A

For seed examples, confirm this is not presented as collected from a public source:

- [ ] This is a seed pattern, not an external citation.

## Quality Checklist

- [x] Each goal has one measurable objective.
- [x] Verification is a command, report, artifact, or explicit manual evidence.
- [x] Constraints prevent scope creep, secret exposure, destructive data changes, and test weakening.
- [x] New examples were generated by `python3 scripts/generate_examples.py`.
- [x] No fixed catalog count was added to README or prompt filenames.

## Validation

- `python3 scripts/generate_examples.py`
- `python3 scripts/validate_data.py`
- `python3 scripts/generate_catalog_health.py`
- `python3 scripts/evaluate_search.py`
- `node --check docs/app.js`
- `python3 -m compileall scripts`
- custom metadata parity check: `docs/examples.json` matches `docs/index.html` counts and JSON-LD item count
- `git diff --check`