### PR TITLE
Clarify source-backed JSON-LD scope

### DIFF
--- a/scripts/generate_examples.py
+++ b/scripts/generate_examples.py
@@ -312,6 +312,8 @@ def build_json_ld(entries: list[dict[str, str | None]]) -> str:
                 "description": f"{source_backed} source-backed task contracts in the primary catalog.",
                 "numberOfItems": source_backed,
                 "itemListOrder": "https://schema.org/ItemListOrderAscending",
+                # Keep the linked ItemList scoped to evidence-backed catalog entries;
+                # seed patterns are counted in Dataset metadata but omitted here.
                 "itemListElement": [
                     {
                         "@type": "ListItem", "position": index, "url": f"{site_url}#{entry['slug']}",

--- a/scripts/validate_metadata.py
+++ b/scripts/validate_metadata.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Validate generated catalog metadata against docs/examples.json."""
+"""Validate generated catalog metadata against docs/examples.json.
+
+The JSON-LD ItemList is intentionally scoped to source-backed entries. Seed
+patterns are counted in Dataset and social metadata, but not listed as primary
+evidence-backed contracts.
+"""
 
 from __future__ import annotations
 
@@ -95,25 +100,50 @@ def main() -> None:
         f"plus {seed_count} reusable seed patterns in the extended library."
     )
     assert_equal("Dataset description", dataset.get("description"), dataset_description)
-    assert_equal("ItemList numberOfItems", item_list.get("numberOfItems"), source_count)
     assert_equal(
-        "ItemList description",
+        "Source-backed ItemList name",
+        item_list.get("name"),
+        "Source-Backed Goal Prompt Contracts",
+    )
+    assert_equal(
+        "Source-backed ItemList numberOfItems",
+        item_list.get("numberOfItems"),
+        source_count,
+    )
+    assert_equal(
+        "Source-backed ItemList description",
         item_list.get("description"),
         f"{source_count} source-backed task contracts in the primary catalog.",
     )
 
     items = item_list.get("itemListElement")
     if not isinstance(items, list):
-        fail("ItemList itemListElement must be a list")
-    assert_equal("ItemList item count", len(items), source_count)
+        fail("Source-backed ItemList itemListElement must be a list")
+    assert_equal("Source-backed ItemList item count", len(items), source_count)
 
     for position, (entry, item) in enumerate(zip(source_entries, items), start=1):
         if not isinstance(item, dict):
-            fail(f"ItemList item {position} must be an object")
-        assert_equal(f"ItemList item {position} position", item.get("position"), position)
-        assert_equal(f"ItemList item {position} url", item.get("url"), f"{SITE_URL}#{entry['slug']}")
-        assert_equal(f"ItemList item {position} name", item.get("name"), entry.get("title"))
-        assert_equal(f"ItemList item {position} description", item.get("description"), entry.get("intent"))
+            fail(f"Source-backed ItemList item {position} must be an object")
+        assert_equal(
+            f"Source-backed ItemList item {position} position",
+            item.get("position"),
+            position,
+        )
+        assert_equal(
+            f"Source-backed ItemList item {position} url",
+            item.get("url"),
+            f"{SITE_URL}#{entry['slug']}",
+        )
+        assert_equal(
+            f"Source-backed ItemList item {position} name",
+            item.get("name"),
+            entry.get("title"),
+        )
+        assert_equal(
+            f"Source-backed ItemList item {position} description",
+            item.get("description"),
+            entry.get("intent"),
+        )
 
     print(f"metadata validation ok ({source_count} source-backed, {seed_count} seed patterns)")
 


### PR DESCRIPTION
## Summary

- Follow up on #6 by making the JSON-LD ItemList scope explicit in the generator and metadata validator.
- Add a validator assertion for the source-backed ItemList name so future metadata changes cannot silently broaden or mislabel the list.
- Update validation failure labels to say `Source-backed ItemList`, reducing ambiguity when counts differ from the full catalog.

## Example Type

- [ ] Source-backed example
- [ ] Seed/catalog example
- [x] Documentation or tooling change

## Source Evidence

For source-backed examples, add the public URL here:

- Source name: N/A
- Source URL: N/A
- Source type: N/A
- Evidence phrase: N/A
- Evidence summary generated by `python3 scripts/generate_examples.py`: N/A

For seed examples, confirm this is not presented as collected from a public source:

- [ ] This is a seed pattern, not an external citation.

## Quality Checklist

- [x] Each goal has one measurable objective.
- [x] Verification is a command, report, artifact, or explicit manual evidence.
- [x] Constraints prevent scope creep, secret exposure, destructive data changes, and test weakening.
- [x] New examples were generated by `python3 scripts/generate_examples.py`.
- [x] No fixed catalog count was added to README or prompt filenames.

## Validation

- `python3 scripts/generate_examples.py`
- `python3 scripts/validate_data.py`
- `python3 scripts/validate_metadata.py`
- `python3 scripts/generate_catalog_health.py`
- `python3 scripts/evaluate_search.py`
- `node --check docs/app.js`
- `python3 -m compileall scripts`
- `git diff --check`
