### PR TITLE
Add make-goal skill

### DIFF
--- a/skills/make-goal/SKILL.md
+++ b/skills/make-goal/SKILL.md
@@ -64,7 +64,7 @@ Read:
 When reviewing generated output, run the bundled linter if a local shell is available:
 
 ```bash
-python3 /Users/lifcc/.agents/skills/make-goal/scripts/lint_goal.py <goal-or-response.md>
+python3 scripts/lint_goal.py <goal-or-response.md>
 ```
 
 Use `--profile data-migration`, `--profile security-xss`, `--profile read-only`, or `--profile clarify` when the task type is known. Use `--json` when another script will consume the result.

--- a/skills/make-goal/SKILL.md
+++ b/skills/make-goal/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: make-goal
+description: Create, tighten, or review runnable /goal contracts for coding agents such as Codex, Claude Code, Cursor, and similar agent tools. Use when the user asks to write, make, generate, improve, productize, or critique a goal prompt, rescue contract, GOAL.md-style task, done-when contract, verification prompt, stop-rule prompt, or when they want to convert a vague engineering request, issue, PR, CI failure, bug report, plan, or backlog item into one measurable coding-agent task. Prefer source-backed goal patterns when available, use seed patterns only as raw reusable shapes, and output the goal contract or review rather than implementing the underlying code task.
+---
+
+# Make Goal
+
+Use this skill to turn engineering intent into a runnable task contract for an agent. The output is a `/goal` contract, a review of an existing goal, or a catalog-entry draft when explicitly requested. Do not implement the underlying software task unless the user separately asks for execution.
+
+A good goal is not a wish. It is a contract with one measurable objective, real context to inspect, hard constraints, auditable completion, fresh verification, and stop rules for uncertainty or risk.
+
+## Operating Modes
+
+- `create`: The user gives a task, issue, failure, plan, or vague request and wants a new `/goal`.
+- `tighten`: The user gives an existing draft and wants it made safer or more executable.
+- `review`: The user asks whether a goal is good; lead with defects, missing evidence, and risk.
+- `catalog`: The user wants to add a goal pattern to an awesome-goal-prompts style catalog; read `references/catalog-contribution.md`.
+
+If the user asks for a goal and also asks you to execute it, first produce the goal contract. Execute only after the user confirms or separately asks for execution.
+
+## Read Context First
+
+Before drafting, inspect available context instead of guessing:
+
+1. Read the user's latest request and any pasted error, issue, plan, or draft.
+2. If working in a repository, read the nearest `AGENTS.md` or `CLAUDE.md`, relevant issue/PLAN/docs/logs, and the files or commands named by the user.
+3. If the task references CI, tests, browser behavior, screenshots, migrations, production, data, auth, or security, include the concrete evidence source in `CONTEXT`.
+4. Separate confirmed facts from assumptions. Do not present assumptions as facts.
+
+Ask at most three concise questions only when missing information changes the contract. The highest-value questions are:
+
+- What is the one finish line for this goal?
+- What real files, issue, logs, screenshots, failing command, or baseline must be read first?
+- What must not change, and what command/report/screenshot proves completion?
+
+If the request is only "make this project better", "fix everything", or similarly broad, use `clarify_first`: ask for the primary goal, context, and done-when condition instead of drafting a fake comprehensive goal.
+
+## Choose The Shape
+
+Use the full shape by default. Use compact only for routine, low-risk work with clear context and a simple verification command.
+
+Use full when any of these are true:
+
+- The task is high-risk, multi-step, long-running, cross-module, migration, security, auth, data, deployment, production, or user-visible frontend work.
+- The user mentions plan mode, AGENTS/CLAUDE rules, screenshots, browser smoke tests, CI repair, database changes, or PR readiness.
+- The constraints are unclear or the task could drift into unrelated cleanup.
+
+Read `references/contract-shape.md` for the full and compact templates.
+
+## Pattern Selection
+
+Use source-backed patterns first when a close match exists. They are trusted shapes backed by public examples, not text to copy verbatim.
+
+Use seed patterns only as raw reusable shapes when no source-backed pattern fits. Never describe a seed as collected from X, GitHub, docs, or a named author.
+
+Read:
+
+- `references/pattern-selection.md` when choosing between source-backed and seed patterns.
+- `references/source-backed-index.md` for common rescue contracts and goal-workflow patterns.
+- `references/seed-patterns-index.md` only when the source-backed index lacks a close shape.
+
+## Optional Lint
+
+When reviewing generated output, run the bundled linter if a local shell is available:
+
+```bash
+python3 /Users/lifcc/.agents/skills/make-goal/scripts/lint_goal.py <goal-or-response.md>
+```
+
+Use `--profile data-migration`, `--profile security-xss`, `--profile read-only`, or `--profile clarify` when the task type is known. Use `--json` when another script will consume the result.
+
+## Required Contract
+
+Every full goal must contain exactly these sections:
+
+```text
+/goal
+GOAL:
+<One measurable goal.>
+
+CONTEXT:
+- <Files, docs, issues, logs, screenshots, commands, baseline, and conventions to inspect first.>
+
+CONSTRAINTS:
+- <What must not change; what must be preserved; safety, data, security, test, and scope boundaries.>
+
+DONE WHEN:
+- <Mechanically auditable completion condition.>
+
+VERIFY:
+- <Fresh command, report, screenshot, artifact, manual check, or explicit blocker.>
+
+OUTPUT:
+- <Changed files if execution occurs, key decisions, verification output, remaining risk, follow-up.>
+
+STOP RULES:
+- <When to pause instead of guessing.>
+```
+
+Compact form:
+
+```text
+/goal <single measurable goal>
+
+Read first: <files/issues/logs>.
+Constraints: <what must not change; what must be preserved>.
+Done when: <mechanically checkable end state>.
+Verify with: <commands/reports/screenshots/evidence>.
+Stop if: <missing input, destructive operation, repeated failed fixes, production access, or unclear product decision>.
+Final output: <changed files, verification, risks, next action>.
+```
+
+## Safety Defaults
+
+Include these constraints unless they conflict with a more specific user requirement:
+
+- Keep scope limited to this goal; do not add unrelated cleanup or "easy improvements".
+- Do not weaken tests, delete assertions, bypass lint/typecheck, or mask errors to make verification pass.
+- Respect repository instructions and existing patterns.
+- Stop if secrets, production access, destructive data operations, missing credentials, or product decisions are required.
+- Stop after three failed attempts on the same symptom and revisit the root-cause hypothesis.
+- Do not mark complete until the current state has been checked against `DONE WHEN`.
+
+For full goals that may lead to file edits, include the scope, test-integrity, and repository-instruction defaults as actual `CONSTRAINTS` text, not only as internal guidance.
+
+Add category-specific constraints when relevant:
+
+- Security: preserve auth/authz, validate inputs, avoid unsafe HTML sinks, string-built SQL, shell string execution, and secret exposure.
+- Data and migrations: write the literal term `dry-run` into the goal. Require a `dry-run` when the stack supports it; if true dry-run is unavailable, say so explicitly and require a disposable-environment rehearsal instead. Also require rollback or forward-only recovery notes, row-count/checksum or equivalent integrity evidence, and no silent data loss.
+- Frontend: preserve accessibility, keyboard behavior, existing design system, and include browser or screenshot evidence for user-visible changes.
+- CI/testing: reproduce or locate the current failure, fix production or fixture causes before changing assertions, and require fresh command output.
+- Investigation: keep changes read-only unless the goal explicitly asks for a fix; separate evidence from hypotheses.
+
+Read `references/quality-bar.md` before finalizing high-risk goals.
+
+## Output Rules
+
+When creating or tightening a goal:
+
+1. Output the final contract in one fenced `text` block.
+2. After the block, add a short note only if needed: assumptions made, missing context, or why full/compact was chosen.
+3. Do not include lengthy internal analysis or catalog trivia.
+
+When reviewing a goal:
+
+1. Lead with findings ordered by severity.
+2. Cite missing sections, vague done conditions, unverifiable `VERIFY`, unsafe constraints, or weak stop rules.
+3. Provide a revised contract if the user asked for one.
+
+When writing a catalog entry:
+
+1. Read `references/catalog-contribution.md`.
+2. Distinguish `source-backed` from `seed`.
+3. Do not invent source metadata.
+
+## Final Self-Check
+
+Before responding, verify:
+
+- There is one primary goal, not a backlog.
+- `CONTEXT` names real files, issues, logs, docs, commands, screenshots, or baselines when available.
+- `CONSTRAINTS` say what must not change.
+- `DONE WHEN` is mechanically checkable or evidence-based.
+- `VERIFY` requires fresh evidence from the actual run or an exact blocker.
+- `STOP RULES` cover secrets, production access, destructive operations, unclear decisions, and repeated failed fixes.
+- Seed patterns are not presented as source-backed evidence.

--- a/skills/make-goal/evals/evals.json
+++ b/skills/make-goal/evals/evals.json
@@ -1,0 +1,65 @@
+{
+  "skill_name": "make-goal",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Write a goal for this repo: fix failing auth tests. The agent must reproduce first, then run npm test -- auth and npm run lint.",
+      "expected_output": "A full /goal contract with GOAL, CONTEXT, CONSTRAINTS, DONE WHEN, VERIFY, OUTPUT, STOP RULES; includes both commands, reproduction/baseline, and test-integrity constraints.",
+      "files": [],
+      "assertions": [
+        {"name": "has_full_goal_sections", "type": "contains_all", "values": ["GOAL:", "CONTEXT:", "CONSTRAINTS:", "DONE WHEN:", "VERIFY:", "OUTPUT:", "STOP RULES:"]},
+        {"name": "preserves_requested_commands", "type": "contains_all", "values": ["npm test -- auth", "npm run lint"]},
+        {"name": "requires_reproduction_or_baseline", "type": "contains_any", "values": ["reproduce", "baseline", "failing output"]},
+        {"name": "protects_test_integrity", "type": "contains_any", "values": ["Do not weaken tests", "Do not delete assertions", "Do not weaken"] }
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Make a read-only goal to investigate why active subscriptions show an empty billing state. Do not edit files.",
+      "expected_output": "A read-only investigation /goal whose DONE WHEN is a root-cause report with evidence; it must not instruct code edits or patches.",
+      "files": [],
+      "assertions": [
+        {"name": "has_full_goal_sections", "type": "contains_all", "values": ["GOAL:", "CONTEXT:", "CONSTRAINTS:", "DONE WHEN:", "VERIFY:", "OUTPUT:", "STOP RULES:"]},
+        {"name": "states_read_only_boundary", "type": "contains_any", "values": ["read-only", "Do not edit files", "Do not modify"]},
+        {"name": "done_when_root_cause_report", "type": "contains_all", "values": ["root cause", "evidence"]},
+        {"name": "does_not_instruct_patch", "type": "not_contains_any", "values": ["apply a fix", "patch the code", "edit implementation"] }
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Generate a goal to add a unique index to users.email in a large production database.",
+      "expected_output": "A high-risk full /goal with migration dry-run, rollback, row-count/checksum or equivalent evidence, and stop rules for production credentials or destructive operations.",
+      "files": [],
+      "assertions": [
+        {"name": "has_full_goal_sections", "type": "contains_all", "values": ["GOAL:", "CONTEXT:", "CONSTRAINTS:", "DONE WHEN:", "VERIFY:", "OUTPUT:", "STOP RULES:"]},
+        {"name": "requires_migration_safety_evidence", "type": "contains_all", "values": ["dry-run", "rollback"]},
+        {"name": "requires_data_integrity_check", "type": "contains_any", "values": ["row count", "checksum", "duplicate"]},
+        {"name": "stops_on_production_or_destructive_access", "type": "contains_all", "values": ["production", "destructive"] }
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Generate a goal to fix a frontend XSS risk from user-provided links.",
+      "expected_output": "A security-focused full /goal that requires protocol allowlist validation, avoids blacklist-only guidance, mentions unsafe sinks such as innerHTML when relevant, and includes tests or browser smoke evidence.",
+      "files": [],
+      "assertions": [
+        {"name": "has_full_goal_sections", "type": "contains_all", "values": ["GOAL:", "CONTEXT:", "CONSTRAINTS:", "DONE WHEN:", "VERIFY:", "OUTPUT:", "STOP RULES:"]},
+        {"name": "requires_protocol_allowlist", "type": "contains_any", "values": ["protocol allowlist", "protocol whitelist", "allowlist"]},
+        {"name": "mentions_unsafe_sinks_or_html", "type": "contains_any", "values": ["innerHTML", "unsafe HTML", "unsafe sink"]},
+        {"name": "requires_test_or_browser_evidence", "type": "contains_any", "values": ["test", "browser", "Playwright", "smoke"] }
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Help me make this project better.",
+      "expected_output": "A clarify-first response asking for the primary goal, real context, constraints, and done-when evidence; it should not generate a broad execution goal.",
+      "files": [],
+      "assertions": [
+        {"name": "clarifies_instead_of_executing", "type": "contains_any", "values": ["primary goal", "one finish line", "What is the one"]},
+        {"name": "asks_for_context", "type": "contains_any", "values": ["files", "issue", "logs", "context"]},
+        {"name": "asks_for_done_when_or_verification", "type": "contains_any", "values": ["done", "verify", "completion", "proves"]},
+        {"name": "does_not_emit_full_goal_contract", "type": "not_contains_any", "values": ["/goal\nGOAL:", "CONSTRAINTS:", "STOP RULES:"] }
+      ]
+    }
+  ]
+}

--- a/skills/make-goal/references/catalog-contribution.md
+++ b/skills/make-goal/references/catalog-contribution.md
@@ -1,0 +1,67 @@
+# Catalog Contribution
+
+Use this only when the user wants to add or update an entry in an awesome-goal-prompts style catalog.
+
+## Source Files
+
+Edit source data, not generated outputs.
+
+- Add or update entries in `data/source/entries.toml`.
+- Category metadata lives in `data/source/categories.toml`.
+- Start-here recipes live in `data/source/recipes.toml`.
+- Generated outputs include `README.md` generated regions, `data/examples.json`, `docs/examples.json`, `prompts/goal-examples.md`, `prompts/source-backed-goals.md`, `prompts/seed-patterns.md`, and catalog health docs.
+
+## Entry Fields
+
+Seed entry:
+
+- `id`
+- `category`
+- `title`
+- `intent`
+- `verify`
+- `origin = "seed"`
+
+Source-backed entry:
+
+- All seed fields.
+- `source_name`
+- `source_url`
+- `source_type`
+- `evidence`
+- `origin = "source-backed"`
+
+Generated fields such as `slug`, `difficulty`, `prompt`, and `evidence_summary` should not be hand-written in source TOML. `slug` follows `id`; `difficulty` comes from category metadata.
+
+## Source Rules
+
+`source-backed` means the entry is tied to a public URL and a concrete task, example, or usage rule. It does not mean the prompt text is copied verbatim.
+
+`seed` means the entry is a reusable pattern. Do not present it as collected from X, GitHub, docs, or a named author.
+
+If a seed later gets real public evidence, update the existing entry with source metadata instead of adding a duplicate.
+
+## Quality Checklist
+
+- The task has exactly one primary objective.
+- The done condition is mechanically checkable or evidence-based.
+- The constraints prevent scope creep.
+- The verification does not depend on prior claims or stale logs.
+- The stop rules cover missing secrets, missing production access, destructive data operations, and repeated failed fixes.
+- Source-backed examples include a public URL, source type, evidence phrase, and generated evidence summary.
+- Seed examples are not presented as external citations.
+
+## Validation Commands
+
+Run these from the catalog repository when contributing:
+
+```bash
+python3 scripts/validate_data.py
+python3 scripts/generate_examples.py
+python3 scripts/generate_catalog_health.py
+python3 scripts/evaluate_search.py
+node --check docs/app.js
+git diff --check
+```
+
+CI should also check that generated files are committed by running `git diff --exit-code` after regeneration.

--- a/skills/make-goal/references/contract-shape.md
+++ b/skills/make-goal/references/contract-shape.md
@@ -1,0 +1,93 @@
+# Contract Shape
+
+A `/goal` is a task contract, not a wish. It tells the agent what to reach, what to inspect, what must not change, how completion will be proven, and when to stop instead of guessing.
+
+## Full Template
+
+Use this by default, especially for high-risk, multi-step, cross-module, long-running, migration, security, data, production, CI, or user-visible frontend work.
+
+```text
+/goal
+GOAL:
+<One clear, measurable goal. Do not include unrelated backlog items.>
+
+CONTEXT:
+- Repository or product area:
+- Files, docs, issues, logs, screenshots, or plans to read first:
+- Current known failure, gap, or baseline:
+- Important project conventions:
+
+CONSTRAINTS:
+- Do not change:
+- Must preserve:
+- Security/data/test constraints:
+- Scope boundaries and non-goals:
+
+DONE WHEN:
+- <Concrete completion condition 1>
+- <Concrete completion condition 2>
+- <Concrete completion condition 3>
+
+VERIFY:
+- Run:
+- Inspect:
+- Capture:
+- If verification cannot run, stop and explain the exact blocker.
+
+OUTPUT:
+- Changed files:
+- Key decisions:
+- Verification output:
+- Remaining risk:
+- Follow-up:
+
+STOP RULES:
+- Stop on missing secrets, production credentials, destructive data operations, or product decisions.
+- Stop after three failed attempts on the same symptom and revisit the root-cause hypothesis.
+- Do not mark complete until the current state has been checked against DONE WHEN.
+```
+
+## Compact Template
+
+Use compact only for routine, scoped, low-risk work where the context and verification command are already clear.
+
+```text
+/goal <single measurable goal>
+
+Read first: <files/issues/logs>.
+Constraints: <what must not change; what must be preserved>.
+Done when: <mechanically checkable end state>.
+Verify with: <commands/reports/screenshots/evidence>.
+Stop if: <missing input, destructive operation, repeated failed fixes, production access, or unclear product decision>.
+Final output: <changed files, verification, risks, next action>.
+```
+
+## Six Moves
+
+1. Make the goal singular. One goal can be large, but it needs one finish line.
+2. Point at real context: issue, files, logs, failing command, design doc, screenshots, or branch state.
+3. Add hard constraints: API compatibility, forbidden files, data safety, security rules, test integrity, non-goals.
+4. Define completion mechanically with `DONE WHEN`.
+5. Require fresh verification: commands, reports, screenshots, logs, artifacts, or explicit blocker.
+6. Give the agent an escape hatch for secrets, production access, destructive data work, unclear decisions, and repeated failed fixes.
+
+## Review Checklist
+
+- The goal has exactly one primary objective.
+- The context names real files, issues, logs, docs, screenshots, or commands.
+- The constraints say what must not change.
+- `DONE WHEN` can be audited from repository state or artifacts.
+- `VERIFY` uses fresh commands or evidence from this run.
+- Stop rules cover secrets, production access, destructive operations, unclear decisions, and repeated failed fixes.
+- The final output asks for changed files, verification, decisions, risks, and next action.
+
+## Avoid
+
+Replace vague language with measurable proof:
+
+- "make no mistakes"
+- "fix everything"
+- "do whatever it takes"
+- "improve the codebase"
+- "keep going until perfect"
+- "use your best judgment" without constraints

--- a/skills/make-goal/references/pattern-selection.md
+++ b/skills/make-goal/references/pattern-selection.md
@@ -1,0 +1,58 @@
+# Pattern Selection
+
+The awesome-goal-prompts catalog separates source-backed examples from seed patterns. Preserve that boundary.
+
+## Source-Backed
+
+Use a source-backed pattern when a close match exists and credibility matters.
+
+Source-backed means:
+
+- It is tied to a public URL and a concrete task, example, or usage rule.
+- It has source metadata such as `source_name`, `source_url`, `source_type`, and `evidence`.
+- The goal contract is rewritten as a reusable task contract; it is not copied verbatim from the source.
+
+Do not claim source-backed status unless source metadata exists.
+
+Common source types include:
+
+- `official-goal`
+- `official-workflow`
+- `official-agent-task`
+- `third-party-tutorial`
+- `third-party-review`
+- `third-party-project`
+- `x-post`
+- `public-forum`
+- `github-issue`
+- `github-pr`
+- `github-discussion`
+- `tool-readme`
+- `video-summary`
+
+## Seed
+
+Use a seed pattern when no source-backed pattern fits but a reusable shape is useful.
+
+Seed means:
+
+- It is a reusable catalog pattern.
+- It is not presented as collected from X, GitHub, docs, a tutorial, or a named author.
+- It can later be promoted to source-backed only by adding real source metadata to the existing entry, not by duplicating it.
+
+## Selection Procedure
+
+1. Identify the user's task type and risk: fix, build, review, read-only investigation, migration, CI, security, data, frontend, docs, or plan.
+2. Check `source-backed-index.md` for a close source-backed shape.
+3. If no close source-backed pattern exists, check `seed-patterns-index.md`.
+4. Adapt the shape to the user's real repository files, commands, constraints, and evidence.
+5. Do not leave catalog placeholders such as generic `npm test` if the user provided a better local command.
+6. If no pattern fits, use the base contract shape and make assumptions explicit.
+
+## Do Not
+
+- Do not copy a catalog prompt unchanged when the user's repository has different files or commands.
+- Do not treat recipe filters as prompt templates.
+- Do not invent a source URL, source type, category, or evidence phrase.
+- Do not let pattern matching override the user's explicit constraints.
+- Do not use a broad seed when a more specific source-backed pattern matches.

--- a/skills/make-goal/references/quality-bar.md
+++ b/skills/make-goal/references/quality-bar.md
@@ -1,0 +1,84 @@
+# Quality Bar
+
+Use this reference before finalizing high-risk goals or reviewing an existing goal.
+
+## Accept Good Goals
+
+Accept or generate goals that:
+
+- Have one real engineering scenario and one primary objective.
+- Include deterministic verification where possible.
+- Protect tests, data, secrets, user-visible behavior, and production systems.
+- Name real context instead of asking the agent to guess.
+- Teach or reuse a pattern that is meaningfully different from existing examples.
+- Include an incomplete state when local verification or access is impossible.
+
+## Reject Weak Goals
+
+Reject or tighten goals that:
+
+- Say only "optimize the app", "fix all bugs", "make it better", or similar.
+- Ask the agent to weaken tests, swallow errors, invent contracts, or bypass auth.
+- Require reading, printing, or hardcoding secrets.
+- Ask for automatic merge, force push, or production deployment without explicit human approval.
+- Differ from an existing goal only by framework, language, or wording.
+- Claim completion without fresh verification.
+
+## Non-Negotiable Sections
+
+Every full goal needs:
+
+- `GOAL`: one objective, not a backlog.
+- `CONTEXT`: what the agent must inspect before acting.
+- `CONSTRAINTS`: boundaries, non-goals, and safety rules.
+- `DONE WHEN`: a measurable completion state.
+- `VERIFY`: exact command, artifact, report, screenshot, or manual evidence.
+- `OUTPUT`: what the final report must contain.
+- `STOP RULES`: when to pause instead of guessing.
+
+## Safety Constraints By Risk
+
+Security and auth:
+
+- Do not bypass authentication, authorization, validation, or audit checks.
+- Do not use unsafe HTML injection, `eval`, shell string concatenation, or string-built SQL.
+- Validate URLs and links with allowlists such as protocol allowlists instead of blacklist-only checks.
+- Do not print, copy, rotate, or exfiltrate real secrets.
+
+Data and migrations:
+
+- Do not destroy or rewrite data without the goal explicitly naming `dry-run`. Require a `dry-run` when supported; if true dry-run is unavailable, state that and require a disposable-environment rehearsal instead. Also require rollback or forward-only recovery notes, and row-count/checksum or equivalent evidence.
+- Do not hide database errors behind warnings or silent fallbacks.
+- Stop if production credentials or destructive operations are required.
+
+Tests and CI:
+
+- Do not weaken lint, typecheck, coverage, or test rules to create a green result.
+- Do not delete or weaken failing tests.
+- Reproduce failures or locate current failing evidence before changing production code.
+- Final verification must come from the current run, not stale claims.
+
+Frontend and design:
+
+- Do not rewrite unrelated routes or replace the design system.
+- Preserve accessibility and keyboard behavior unless the goal explicitly changes them.
+- Use browser, screenshot, or Playwright evidence for user-visible changes when feasible.
+
+Investigation:
+
+- Separate observed evidence from hypotheses.
+- Do not patch production code until the root cause is reproduced or strongly evidenced.
+- If the goal is read-only, make the non-edit boundary explicit.
+
+Agent workflow:
+
+- Do not claim a goal is complete without auditing the current goal text and state.
+- Pause if the goal text, branch state, permission context, or repository rules conflict.
+- Preserve AGENTS.md/CLAUDE.md rules through long-running work and compaction.
+
+## Deduplication
+
+- Same goal plus same verification is a duplicate.
+- Prefer a more specific goal over a broad goal.
+- Prefer concrete verification over subjective judgment.
+- Keep broad categories as references, not as excuses to create vague goals.

--- a/skills/make-goal/references/seed-patterns-index.md
+++ b/skills/make-goal/references/seed-patterns-index.md
@@ -1,0 +1,90 @@
+# Seed Patterns Index
+
+Use seed patterns only as raw reusable shapes when no close source-backed pattern fits. Do not cite them as external evidence.
+
+## Category Taxonomy
+
+- `backend-api`: routes, OpenAPI specs, handlers, middleware, API tests.
+- `backend-data`: schema files, migrations, models, repositories, data tests.
+- `devops-ci`: workflow files, build scripts, package manifests, CI logs.
+- `devops-runtime`: Dockerfiles, deployment manifests, runtime config, health checks.
+- `security-appsec`: auth, input handling, rendering, upload, boundary tests.
+- `security-ops`: workflow permissions, cloud IAM, release artifacts, audit evidence.
+- `data-eng`: ETL jobs, schemas, source contracts, transformations, data quality tests.
+- `data-analytics`: metric SQL, event schemas, dashboards, validation queries.
+- `ai-evals`: eval datasets, rubrics, model outputs, judge code, regression reports.
+- `ai-ops`: prompts, retrieval, routing, tracing, cost logs.
+- `frontend`: routes, components, state, stories, tests, screenshots.
+- `design`: design tokens, component variants, layouts, visual states, screenshots.
+- `mobile`: mobile routes, forms, gestures, device matrix, viewport tests.
+- `docs`: README, docs, examples, runbooks, lint config.
+- `product`: PRDs, analytics events, permission models, acceptance criteria.
+- `qa`: test suites, fixtures, bug templates, release checklists.
+- `accessibility`: interactive elements, semantics, focus management, a11y reports.
+- `performance`: Lighthouse reports, bundles, traces, critical routes.
+- `workflow`: goal text, progress logs, branch state, verification artifacts.
+- `migration`: legacy code, target implementation, compatibility tests, snapshots.
+- `prototype`: PLAN.md, milestones, app code, tests, browser checks.
+- `prompt-optimization`: prompt files, eval cases, scoring reports, failures.
+- `testing`: tests, lint config, CI logs, coverage reports, failing output.
+- `investigation`: logs, traces, reproduction notes, source paths, final report.
+- `cli`: CLI entrypoints, argument parsing, filesystem behavior, fixtures.
+- `refactor`: target module, call sites, public API, tests, compatibility notes.
+
+## High-Value Seed Shapes
+
+Backend API:
+
+- API Contract Drift Audit: compare OpenAPI, implementation, and tests.
+- Request Validation Boundary: move validation to the API boundary and reject unknown fields.
+- Resource-Level Authorization: prevent cross-resource access.
+- Idempotent Create Endpoint: add idempotency keys and replay-safe semantics.
+- API Error Taxonomy: unify HTTP status, machine codes, user messages, and logs.
+
+Backend data:
+
+- Database Migration Safety: review rollback, online execution, and lock risk.
+- Transaction Boundary Audit: find missing or oversized transactions.
+- Cache Invalidation Map: map write paths to cache keys and stale reads.
+- Schema Drift Detector: compare models, migrations, and live schema.
+- Read Replica Lag Guard: prevent stale read-after-write behavior.
+
+Security:
+
+- SQL Injection Audit: replace string-built SQL with parameterized queries and tests.
+- Command Injection Audit: replace shell strings with argument arrays and validation.
+- SSRF Defense Review: add URL allowlists and DNS/IP checks.
+- XSS Output Encoding: audit rendering sinks and missing encoding.
+- IDOR Audit: verify ownership or scope checks for direct object access.
+
+Frontend and design:
+
+- Form Validation UX: align client/server validation and error display.
+- Empty State Behavior: ensure no-data states are honest and recoverable.
+- Accessibility Color Contrast: verify contrast and state visibility.
+- Keyboard Navigation Repair: preserve focus order and shortcuts.
+- Component API Consistency: align props, states, stories, and tests.
+
+Testing and CI:
+
+- CI Flaky Test Triage: separate flakes from real failures.
+- Dependency Update Gate: require tests, licenses, and vulnerabilities checks.
+- Monorepo Affected Tests: run affected tests without missing contracts.
+- Coverage Gap Closure: add tests for critical uncovered branches.
+
+AI/evals:
+
+- LLM Golden Set Build: build evals from real failures and frequent tasks.
+- LLM Regression Gate: compare old and new model or prompt outputs.
+- Judge Calibration: measure judge agreement against human labels.
+- Tool Use Eval: evaluate tool selection, order, and validation.
+- Hallucination Probe Suite: add negative cases for nonexistent files, fields, APIs, and sources.
+
+Docs and maintenance:
+
+- Docs Quickstart: verify install, run, test, and first-success path.
+- Public API Docs Coverage: add examples for public functions.
+- Repo Maintenance Audit: find dead code, unused dependencies, stale files.
+- Release Notes From Diff: produce user-facing notes from commits and PR labels.
+
+Use a seed by copying its task shape into the full contract and binding it to the user's actual context and verification.

--- a/skills/make-goal/references/source-backed-index.md
+++ b/skills/make-goal/references/source-backed-index.md
@@ -1,0 +1,104 @@
+# Source-Backed Index
+
+Use this as a compact pattern map. Adapt the shape to the user's real repository, files, commands, and constraints.
+
+## Start With Ten Rescue Patterns
+
+| User situation | Pattern | Intent | Verification |
+| --- | --- | --- | --- |
+| Auth tests and lint are both red | Auth Tests And Lint Clean | Keep auth behavior while making tests and lint pass. | `npm test -- test/auth && npm run lint` |
+| CI has mixed test, lint, and typecheck failures | CI Pipeline Green | Repair CI failures until local and remote checks pass. | local CI rerun and remote CI |
+| A migration needs proof | Dev Database Migration Proof | Write/apply a migration and prove schema match. | dev DB migration and schema comparison |
+| A PR may have security bugs | Security PR Review | Review auth, injection, XSS, secrets, and input validation. | severity/line-level PR review |
+| Checkout crashes from a stack trace | Checkout Crash Regression Fix | Reproduce, root-cause, fix, and add regression test. | crash reproduction and regression test |
+| Users see an empty billing state | Billing Empty State Root Cause | Find the cause without changing pricing/webhooks. | tests and root-cause evidence |
+| A visual migration must not drift | Visual Migration With Playwright | Preserve screen output through migration. | `npx playwright test` |
+| Agent runs need traceability | Agent Trace Observability | Add trace spans for one representative agent run. | trace dashboard shows spans |
+| `npm audit` is red | NPM Audit Clean Remediation | Patch vulnerabilities without public API breakage. | `npm audit && npm test` |
+| A plan may have holes | Review Plan Until No Gaps | Loop review until a fresh review finds no gaps. | fresh plan review has no new gaps |
+
+## Goal Workflow Patterns
+
+- Meta Goal Prompt Generator: inspect session, repo, history, and docs before writing the actual `/goal`.
+- AGENTS.md Goal Workflow: combine repository agent rules with `/goal` so constraints survive long work.
+- Plan-Then-Goal Execution: define the work in plan mode, then execute a stable goal.
+- Measurable Goal Structure: require a clear target, proof requirement, and explicit limits.
+- Long Task Until Verification: continue long work until final verification passes.
+- Completion Audit Before Done: audit done criteria before marking completion.
+- Goal Escape Hatch: define an incomplete state for impossible or blocked subtasks.
+
+## Patterns By Intent
+
+Testing and CI:
+
+- Auth Tests And Lint Clean
+- TypeScript ESLint Coverage Gate
+- Ruff Clean Source Tree
+- Tests And Lint Completion
+- CI Pipeline Green
+- Go Race Cleanup
+
+Investigation and regression:
+
+- Checkout Crash Regression Fix
+- Billing Empty State Root Cause
+- Build Log Failure Diagnosis
+- Session Drift Report
+
+Migration:
+
+- Visual Migration With Playwright
+- Feature Port With CI Green
+- Finish Migration Keep Tests Green
+- Module API Migration
+- Moment To Day.js Migration
+- React 19 Migration
+- Pydantic V1 To V2 Migration
+
+Security:
+
+- Security PR Review
+- NPM Audit Clean Remediation
+- Tool Guardrails For AppSec
+
+Frontend and design:
+
+- Button Console Error Fix
+- Fix Freezing Chart Tooltips
+- Visual Feedback With Test Guard
+- Theme Toggle Persistence
+- Reference Layout Match
+- HTML WCAG Instruction Audit
+
+Data and backend:
+
+- Dev Database Migration Proof
+- Slow Query Optimization Report
+- API Integration Tests
+- User Preferences API
+- CSV Processing Report
+- Rate-Limited Web Scraper
+
+AI and agent systems:
+
+- Agent Trace Observability
+- Trace-Graded Agent Regression
+- Eval-Driven Prompt Optimization
+- Router Prompt Eval Score
+- RAG Chat Flywheel
+
+Docs and maintenance:
+
+- Contributor README Rewrite
+- Public API Docs Coverage
+- Weekly Changelog Coverage
+- Repo Maintenance Audit
+- Clean Worktree File Budget
+
+Product and planning:
+
+- Design Doc Acceptance Complete
+- Feature Flag System
+- OKR Development From Vague Priorities
+
+Use these names as pattern cues, not as final user-facing claims unless the user is discussing the catalog itself.

--- a/skills/make-goal/scripts/lint_goal.py
+++ b/skills/make-goal/scripts/lint_goal.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
-import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 

--- a/skills/make-goal/scripts/lint_goal.py
+++ b/skills/make-goal/scripts/lint_goal.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Lint make-goal outputs.
+
+This script checks deterministic properties that are easy to regress:
+required goal sections, fresh verification language, stop rules, and
+profile-specific safety requirements for read-only, data migration, XSS, and
+clarify-first outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+FULL_SECTIONS = [
+    "GOAL:",
+    "CONTEXT:",
+    "CONSTRAINTS:",
+    "DONE WHEN:",
+    "VERIFY:",
+    "OUTPUT:",
+    "STOP RULES:",
+]
+
+VAGUE_PHRASES = [
+    "make it better",
+    "fix everything",
+    "do whatever it takes",
+    "keep going until perfect",
+    "improve the codebase",
+    "use your best judgment",
+]
+
+
+@dataclass
+class Check:
+    id: str
+    severity: str
+    passed: bool
+    message: str
+    evidence: str = ""
+
+
+def normalize(text: str) -> str:
+    return text.lower()
+
+
+def contains_any(text: str, terms: list[str]) -> bool:
+    lowered = normalize(text)
+    return any(term.lower() in lowered for term in terms)
+
+
+def contains_all(text: str, terms: list[str]) -> bool:
+    lowered = normalize(text)
+    return all(term.lower() in lowered for term in terms)
+
+
+def section_positions(text: str) -> dict[str, int]:
+    lowered = normalize(text)
+    return {section: lowered.find(section.lower()) for section in FULL_SECTIONS}
+
+
+def extract_section(text: str, section: str) -> str:
+    positions = section_positions(text)
+    start = positions.get(section, -1)
+    if start < 0:
+        return ""
+    start += len(section)
+    later_positions = [
+        pos
+        for name, pos in positions.items()
+        if pos > start and name != section
+    ]
+    end = min(later_positions) if later_positions else len(text)
+    return text[start:end].strip()
+
+
+def infer_profile(text: str) -> str:
+    lowered = normalize(text)
+    if "/goal" not in lowered and contains_any(lowered, ["primary goal", "one finish line", "what is the one"]):
+        return "clarify"
+    if contains_any(lowered, ["xss", "user-provided link", "javascript:", "innerhtml", "unsafe html"]):
+        return "security-xss"
+    if contains_any(lowered, ["production database", "unique index", "users.email", "migration", "ddl"]):
+        return "data-migration"
+    if contains_any(lowered, ["read-only", "do not edit files", "changed files: `none`", "changed files: none"]):
+        return "read-only"
+    return "general"
+
+
+def check_contract_shape(text: str) -> list[Check]:
+    checks: list[Check] = []
+    checks.append(
+        Check(
+            "has_goal_command",
+            "error",
+            "/goal" in normalize(text),
+            "Goal contracts should include the /goal command.",
+        )
+    )
+    positions = section_positions(text)
+    missing = [section for section, pos in positions.items() if pos < 0]
+    checks.append(
+        Check(
+            "has_full_goal_sections",
+            "error",
+            not missing,
+            "Full goal must include GOAL, CONTEXT, CONSTRAINTS, DONE WHEN, VERIFY, OUTPUT, and STOP RULES.",
+            ", ".join(missing) if missing else "all sections present",
+        )
+    )
+    present_positions = [positions[section] for section in FULL_SECTIONS if positions[section] >= 0]
+    ordered = present_positions == sorted(present_positions)
+    checks.append(
+        Check(
+            "sections_in_order",
+            "error",
+            ordered,
+            "Full goal sections should appear in the standard order.",
+        )
+    )
+    empty_sections = [
+        section
+        for section in FULL_SECTIONS
+        if positions.get(section, -1) >= 0 and not extract_section(text, section)
+    ]
+    checks.append(
+        Check(
+            "sections_nonempty",
+            "error",
+            not empty_sections,
+            "Each full goal section should contain concrete content.",
+            ", ".join(empty_sections) if empty_sections else "all present sections have content",
+        )
+    )
+    goal = extract_section(text, "GOAL:")
+    checks.append(
+        Check(
+            "goal_not_vague",
+            "error",
+            not contains_any(goal, VAGUE_PHRASES),
+            "GOAL must not use vague improvement language.",
+            goal[:180],
+        )
+    )
+    checks.append(
+        Check(
+            "verify_requires_fresh_evidence",
+            "error",
+            contains_any(extract_section(text, "VERIFY:"), ["run ", "capture", "fresh", "current session", "screenshot", "report", "inspect", "if verification cannot run", "stop and report"]),
+            "VERIFY should require fresh command output, report, screenshot, inspection, or an explicit blocker.",
+        )
+    )
+    stop_rules = extract_section(text, "STOP RULES:")
+    checks.append(
+        Check(
+            "stop_rules_cover_high_risk_blockers",
+            "error",
+            contains_all(stop_rules, ["secrets", "production"]) and contains_any(stop_rules, ["destructive", "credentials"]),
+            "STOP RULES should cover secrets, production access, credentials, or destructive operations.",
+            stop_rules[:220],
+        )
+    )
+    checks.append(
+        Check(
+            "stop_rules_cover_repeated_failures",
+            "error",
+            contains_any(stop_rules, ["three failed", "3 failed", "three attempts", "3 attempts"]),
+            "STOP RULES should stop after repeated failed attempts on the same symptom.",
+            stop_rules[:220],
+        )
+    )
+    checks.append(
+        Check(
+            "protects_test_integrity",
+            "warn",
+            contains_any(text, ["do not weaken tests", "do not delete assertions", "test integrity", "do not weaken lint"]),
+            "Goal should protect tests and assertions when implementation or verification is involved.",
+        )
+    )
+    return checks
+
+
+def check_read_only(text: str) -> list[Check]:
+    return [
+        Check(
+            "read_only_boundary",
+            "error",
+            contains_any(text, ["read-only", "do not edit files", "do not modify", "changed files: `none`", "changed files: none"]),
+            "Read-only goals must explicitly forbid edits.",
+        ),
+        Check(
+            "no_patch_instruction",
+            "error",
+            not contains_any(text, ["apply a fix", "patch the code", "edit implementation"]),
+            "Read-only goals must not instruct the agent to patch implementation code.",
+        ),
+        Check(
+            "root_cause_evidence",
+            "error",
+            contains_all(text, ["root cause", "evidence"]),
+            "Read-only investigation goals should require a root-cause report with evidence.",
+        ),
+    ]
+
+
+def check_data_migration(text: str) -> list[Check]:
+    return [
+        Check(
+            "requires_dry_run",
+            "error",
+            "dry-run" in normalize(text),
+            "Data or migration goals must explicitly include the literal term dry-run.",
+        ),
+        Check(
+            "requires_rollback_or_recovery",
+            "error",
+            contains_any(text, ["rollback", "forward-only recovery", "forward-fix", "recovery"]),
+            "Data or migration goals must include rollback or recovery evidence.",
+        ),
+        Check(
+            "requires_integrity_evidence",
+            "error",
+            contains_any(text, ["row count", "row-count", "checksum", "duplicate"]),
+            "Data or migration goals must require integrity evidence such as row counts, checksums, or duplicate reports.",
+        ),
+        Check(
+            "blocks_unsafe_production_work",
+            "error",
+            contains_all(text, ["production", "destructive"]) and contains_any(text, ["stop", "do not"]),
+            "Data or migration goals must block unsafe production or destructive work.",
+        ),
+    ]
+
+
+def check_security_xss(text: str) -> list[Check]:
+    return [
+        Check(
+            "requires_protocol_allowlist",
+            "error",
+            contains_any(text, ["protocol allowlist", "protocol whitelist", "allowlist"]),
+            "XSS link goals must require protocol allowlist validation.",
+        ),
+        Check(
+            "rejects_blacklist_only",
+            "error",
+            contains_any(text, ["do not rely on blacklist", "not rely on blacklist", "blacklist-only", "allowlist"]),
+            "XSS link goals should avoid blacklist-only validation.",
+        ),
+        Check(
+            "mentions_unsafe_sinks",
+            "error",
+            contains_any(text, ["innerhtml", "unsafe html", "unsafe sink", "href", "window.open", "location.href"]),
+            "XSS link goals should mention unsafe HTML or navigation sinks.",
+        ),
+        Check(
+            "requires_browser_or_test_evidence",
+            "error",
+            contains_any(text, ["browser", "playwright", "smoke", "test"]),
+            "XSS link goals should require tests or browser smoke evidence.",
+        ),
+    ]
+
+
+def check_clarify(text: str) -> list[Check]:
+    return [
+        Check(
+            "asks_for_primary_goal",
+            "error",
+            contains_any(text, ["primary goal", "one finish line", "what is the one", "single improvement goal"]),
+            "Clarify-first responses should ask for the primary goal or finish line.",
+        ),
+        Check(
+            "asks_for_context",
+            "error",
+            contains_any(text, ["files", "issue", "logs", "context", "screenshot"]),
+            "Clarify-first responses should ask for real context.",
+        ),
+        Check(
+            "asks_for_done_or_verify",
+            "error",
+            contains_any(text, ["done", "verify", "completion", "proves", "evidence"]),
+            "Clarify-first responses should ask what proves completion.",
+        ),
+        Check(
+            "does_not_emit_full_goal",
+            "error",
+            "/goal\ngoal:" not in normalize(text) and "stop rules:" not in normalize(text),
+            "Clarify-first responses should not emit a full goal contract.",
+        ),
+    ]
+
+
+def lint(text: str, profile: str) -> tuple[str, list[Check]]:
+    selected = infer_profile(text) if profile == "auto" else profile
+    checks: list[Check] = []
+    if selected == "clarify":
+        checks.extend(check_clarify(text))
+        return selected, checks
+    checks.extend(check_contract_shape(text))
+    if selected == "read-only":
+        checks.extend(check_read_only(text))
+    elif selected == "data-migration":
+        checks.extend(check_data_migration(text))
+    elif selected == "security-xss":
+        checks.extend(check_security_xss(text))
+    elif selected != "general":
+        raise SystemExit(f"unknown profile: {selected}")
+    return selected, checks
+
+
+def print_text(path: Path, profile: str, checks: list[Check]) -> None:
+    failed_errors = [check for check in checks if not check.passed and check.severity == "error"]
+    failed_warnings = [check for check in checks if not check.passed and check.severity == "warn"]
+    if failed_errors:
+        status = "FAIL"
+    elif failed_warnings:
+        status = "PASS_WITH_WARNINGS"
+    else:
+        status = "PASS"
+    print(f"{status} {path} profile={profile}")
+    for check in checks:
+        mark = "ok" if check.passed else check.severity
+        print(f"- [{mark}] {check.id}: {check.message}")
+        if check.evidence and not check.passed:
+            print(f"  evidence: {check.evidence}")
+    clean = len(checks) - len(failed_errors) - len(failed_warnings)
+    print(f"summary: {clean}/{len(checks)} checks clean, errors={len(failed_errors)}, warnings={len(failed_warnings)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Lint make-goal output files.")
+    parser.add_argument("path", type=Path, help="Markdown/text file to lint")
+    parser.add_argument(
+        "--profile",
+        choices=["auto", "general", "read-only", "data-migration", "security-xss", "clarify"],
+        default="auto",
+        help="Lint profile. auto infers from the file content.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    parser.add_argument("--strict-warnings", action="store_true", help="Treat warnings as failures")
+    args = parser.parse_args()
+
+    text = args.path.read_text(encoding="utf-8")
+    selected_profile, checks = lint(text, args.profile)
+    failed_errors = [check for check in checks if not check.passed and check.severity == "error"]
+    failed_warnings = [check for check in checks if not check.passed and check.severity == "warn"]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "path": str(args.path),
+                    "profile": selected_profile,
+                    "passed": not failed_errors and not (args.strict_warnings and failed_warnings),
+                    "checks": [asdict(check) for check in checks],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print_text(args.path, selected_profile, checks)
+
+    if failed_errors or (args.strict_warnings and failed_warnings):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add `skills/make-goal`, a skill distilled from the goal contract catalog for creating, tightening, and reviewing runnable `/goal` contracts.
- Include progressive references for contract shape, quality bar, source-backed vs seed selection, catalog contribution rules, and compact indexes.
- Add `skills/make-goal/scripts/lint_goal.py` plus eval prompts for repeatable checks across general, read-only, data migration, XSS, and clarify-first outputs.

## Verification

- `python3 scripts/validate_data.py`
- `python3 scripts/evaluate_search.py`
- `node --check docs/app.js`
- `python3 -m compileall skills/make-goal/scripts scripts`
- `python3 -m json.tool skills/make-goal/evals/evals.json >/dev/null`
- `skills/make-goal/scripts/lint_goal.py <temp-goal.md> --profile general`
- `git diff --check`

## Notes

This PR is split from the existing `clarify-jsonld-source-scope` branch/PR so the make-goal skill can be reviewed independently.
