### PR TITLE
Fix make-goal linter profiles

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Evaluate search quality
         run: python3 scripts/evaluate_search.py
 
+      - name: Evaluate make-goal skill fixtures
+        run: python3 skills/make-goal/scripts/run_evals.py
+
       - name: Check page JavaScript
         run: node --check docs/app.js
 

--- a/skills/make-goal/SKILL.md
+++ b/skills/make-goal/SKILL.md
@@ -37,13 +37,15 @@ If the request is only "make this project better", "fix everything", or similarl
 
 ## Choose The Shape
 
-Use the full shape by default. Use compact only for routine, low-risk work with clear context and a simple verification command.
+Use the full shape by default. Use compact only for routine, low-risk work with clear context and one or two simple verification commands.
 
 Use full when any of these are true:
 
 - The task is high-risk, multi-step, long-running, cross-module, migration, security, auth, data, deployment, production, or user-visible frontend work.
 - The user mentions plan mode, AGENTS/CLAUDE rules, screenshots, browser smoke tests, CI repair, database changes, or PR readiness.
 - The constraints are unclear or the task could drift into unrelated cleanup.
+
+Do not over-process tiny tasks. If the requested change is routine and the diff could be described in one sentence, use compact or answer directly when the user did not ask for a goal.
 
 Read `references/contract-shape.md` for the full and compact templates.
 
@@ -67,7 +69,13 @@ When reviewing generated output, run the bundled linter if a local shell is avai
 python3 scripts/lint_goal.py <goal-or-response.md>
 ```
 
-Use `--profile compact`, `--profile data-migration`, `--profile security-xss`, `--profile read-only`, or `--profile clarify` when the task type is known. Use `--json` when another script will consume the result.
+Use `--profile compact`, `--profile data-migration`, `--profile security-xss`, `--profile read-only`, `--profile launch-readiness`, or `--profile clarify` when the task type is known. Combine profiles with commas, such as `--profile read-only,security-xss`, when a goal has multiple risk modes. Use `--json` when another script will consume the result.
+
+Run the deterministic fixture evals after changing this skill:
+
+```bash
+python3 scripts/run_evals.py
+```
 
 ## Required Contract
 
@@ -115,13 +123,15 @@ Final output: <changed files, verification, risks, next action>.
 Include these constraints unless they conflict with a more specific user requirement:
 
 - Keep scope limited to this goal; do not add unrelated cleanup or "easy improvements".
-- Do not weaken tests, delete assertions, bypass lint/typecheck, or mask errors to make verification pass.
+- Include a `Verification integrity:` constraint when edits, validation, generated outputs, tests, lint, typecheck, screenshots, or external checks are involved. Use this shape: `Verification integrity: do not weaken or bypass tests, assertions, lint, typecheck, validation, generated-output checks, screenshots, or external blockers to make the goal pass; fix the root cause or report the blocker.`
 - Respect repository instructions and existing patterns.
 - Stop if secrets, production access, destructive data operations, missing credentials, or product decisions are required.
 - Stop after three failed attempts on the same symptom and revisit the root-cause hypothesis.
 - Do not mark complete until the current state has been checked against `DONE WHEN`.
 
-For full goals that may lead to file edits, include the scope, test-integrity, and repository-instruction defaults as actual `CONSTRAINTS` text, not only as internal guidance.
+For full goals that may lead to file edits, include the scope, verification-integrity, and repository-instruction defaults as actual `CONSTRAINTS` text, not only as internal guidance.
+
+Keep context precise. Name the minimum useful files, issues, logs, screenshots, URLs, commands, or baselines instead of asking the agent to read the whole repository. Treat `AGENTS.md` and `CLAUDE.md` as context sources with different tool semantics; do not imply every coding agent loads the same instruction files automatically.
 
 Add category-specific constraints when relevant:
 
@@ -132,6 +142,10 @@ Add category-specific constraints when relevant:
 - Investigation: keep changes read-only unless the goal explicitly asks for a fix; separate evidence from hypotheses.
 - Launch/readiness/release-prep: add a scope fuse. If the work expands into multiple independent PR-sized changes, keep the current goal to the smallest launch-readiness pass and list follow-up PRs instead of expanding scope.
 - External platform guidance: distinguish required local acceptance criteria from advisory platform recommendations. Record deviations and decide whether to keep or update; do not imply every recommendation must be implemented or that external outcomes such as trending, ranking, traffic, or approval are guaranteed.
+- Growth/launch plans: treat stars, traffic, virality, Trending placement, rankings, external review approval, and awesome-list acceptance as external outcome targets. Keep the deliverable to a source-backed report, first PR scope, launch sequence, and measurement plan unless the user explicitly asks for execution.
+- Platform settings: if a goal references repository settings, topics, social preview, Pages, GitHub metadata, traffic APIs, or external submissions, document owner-access work as manual steps or exact blockers instead of treating it as completed.
+
+For non-trivial goals, include risk, trade-off, or blast-radius reporting in `OUTPUT` rather than adding a new top-level section.
 
 Read `references/quality-bar.md` before finalizing high-risk goals.
 
@@ -141,7 +155,10 @@ When creating or tightening a goal:
 
 1. Output the final contract in one fenced `text` block.
 2. After the block, add a short note only if needed: assumptions made, missing context, or why full/compact was chosen.
-3. Do not include lengthy internal analysis or catalog trivia.
+3. Ask one concise handoff question after the note: `是否现在启动这个 goal？如果你回复“启动”或“开始执行”，我会先注册 active goal（如果当前运行环境支持），再按这个 contract 执行；否则只保留为可复制的 goal。`
+4. Do not start executing the goal in the same response. If the user confirms in the next message, treat that as an explicit request to execute the most recently generated goal contract.
+5. In Codex or any runtime with an active-goal mechanism, confirmation means: check whether an active goal already exists, call the runtime's goal-registration tool such as `create_goal` with the contract objective before executing, and call the completion tool such as `update_goal` only after `DONE WHEN` and `VERIFY` are satisfied. If no active-goal mechanism is available, say that explicitly before executing manually.
+6. Do not include lengthy internal analysis or catalog trivia.
 
 When reviewing a goal:
 
@@ -163,6 +180,7 @@ Before responding, verify:
 - `CONTEXT` names real files, issues, logs, docs, commands, screenshots, or baselines when available.
 - `CONSTRAINTS` say what must not change.
 - `DONE WHEN` is mechanically checkable or evidence-based.
-- `VERIFY` requires fresh evidence from the actual run or an exact blocker.
-- `STOP RULES` cover secrets, production access, destructive operations, unclear decisions, and repeated failed fixes.
+- `VERIFY` requires fresh evidence from the actual run or an exact blocker, not only a generic phrase such as "run tests".
+- `STOP RULES` cover secrets, production access, destructive operations, repository settings or owner approval when relevant, unclear decisions, and repeated failed fixes.
+- Launch, release-prep, growth, roadmap, Trending, and awesome-list goals include a scope fuse and manual platform blocker language.
 - Seed patterns are not presented as source-backed evidence.

--- a/skills/make-goal/SKILL.md
+++ b/skills/make-goal/SKILL.md
@@ -130,6 +130,8 @@ Add category-specific constraints when relevant:
 - Frontend: preserve accessibility, keyboard behavior, existing design system, and include browser or screenshot evidence for user-visible changes.
 - CI/testing: reproduce or locate the current failure, fix production or fixture causes before changing assertions, and require fresh command output.
 - Investigation: keep changes read-only unless the goal explicitly asks for a fix; separate evidence from hypotheses.
+- Launch/readiness/release-prep: add a scope fuse. If the work expands into multiple independent PR-sized changes, keep the current goal to the smallest launch-readiness pass and list follow-up PRs instead of expanding scope.
+- External platform guidance: distinguish required local acceptance criteria from advisory platform recommendations. Record deviations and decide whether to keep or update; do not imply every recommendation must be implemented or that external outcomes such as trending, ranking, traffic, or approval are guaranteed.
 
 Read `references/quality-bar.md` before finalizing high-risk goals.
 

--- a/skills/make-goal/SKILL.md
+++ b/skills/make-goal/SKILL.md
@@ -67,7 +67,7 @@ When reviewing generated output, run the bundled linter if a local shell is avai
 python3 scripts/lint_goal.py <goal-or-response.md>
 ```
 
-Use `--profile data-migration`, `--profile security-xss`, `--profile read-only`, or `--profile clarify` when the task type is known. Use `--json` when another script will consume the result.
+Use `--profile compact`, `--profile data-migration`, `--profile security-xss`, `--profile read-only`, or `--profile clarify` when the task type is known. Use `--json` when another script will consume the result.
 
 ## Required Contract
 

--- a/skills/make-goal/evals/evals.json
+++ b/skills/make-goal/evals/evals.json
@@ -71,6 +71,18 @@
         {"name": "preserves_requested_commands", "type": "contains_all", "values": ["npm test -- auth", "npm run lint"]},
         {"name": "protects_test_integrity", "type": "contains_any", "values": ["Do not weaken tests", "Do not delete assertions", "Do not weaken"] }
       ]
+    },
+    {
+      "id": 7,
+      "prompt": "Create a goal for a launch-readiness pass before a GitHub Trending push. It should cover README positioning, GitHub Pages first viewport, share-preview assets, and repo metadata guidance, but Trending itself is not guaranteed.",
+      "expected_output": "A full /goal that includes a launch/readiness scope fuse, treats external platform guidance as advisory unless locally required, and explicitly avoids guaranteeing GitHub Trending or similar external outcomes.",
+      "files": [],
+      "assertions": [
+        {"name": "has_full_goal_sections", "type": "contains_all", "values": ["GOAL:", "CONTEXT:", "CONSTRAINTS:", "DONE WHEN:", "VERIFY:", "OUTPUT:", "STOP RULES:"]},
+        {"name": "has_scope_fuse", "type": "contains_any", "values": ["scope fuse", "multiple independent PR-sized changes", "follow-up PRs"]},
+        {"name": "bounds_external_guidance", "type": "contains_any", "values": ["advisory", "external platform", "not guaranteed"]},
+        {"name": "does_not_guarantee_trending", "type": "not_contains_any", "values": ["guarantee GitHub Trending", "guaranteed Trending placement", "guarantee trending placement"] }
+      ]
     }
   ]
 }

--- a/skills/make-goal/evals/evals.json
+++ b/skills/make-goal/evals/evals.json
@@ -60,6 +60,17 @@
         {"name": "asks_for_done_when_or_verification", "type": "contains_any", "values": ["done", "verify", "completion", "proves"]},
         {"name": "does_not_emit_full_goal_contract", "type": "not_contains_any", "values": ["/goal\nGOAL:", "CONSTRAINTS:", "STOP RULES:"] }
       ]
+    },
+    {
+      "id": 6,
+      "prompt": "Create a compact goal for fixing auth tests when the files and commands are already known: read auth routes and tests, run npm test -- auth and npm run lint.",
+      "expected_output": "A compact /goal with Read first, Constraints, Done when, Verify with, Stop if, and Final output; it should preserve the provided commands and test-integrity constraints.",
+      "files": [],
+      "assertions": [
+        {"name": "has_compact_goal_sections", "type": "contains_all", "values": ["/goal", "Read first:", "Constraints:", "Done when:", "Verify with:", "Stop if:", "Final output:"]},
+        {"name": "preserves_requested_commands", "type": "contains_all", "values": ["npm test -- auth", "npm run lint"]},
+        {"name": "protects_test_integrity", "type": "contains_any", "values": ["Do not weaken tests", "Do not delete assertions", "Do not weaken"] }
+      ]
     }
   ]
 }

--- a/skills/make-goal/evals/evals.json
+++ b/skills/make-goal/evals/evals.json
@@ -10,7 +10,7 @@
         {"name": "has_full_goal_sections", "type": "contains_all", "values": ["GOAL:", "CONTEXT:", "CONSTRAINTS:", "DONE WHEN:", "VERIFY:", "OUTPUT:", "STOP RULES:"]},
         {"name": "preserves_requested_commands", "type": "contains_all", "values": ["npm test -- auth", "npm run lint"]},
         {"name": "requires_reproduction_or_baseline", "type": "contains_any", "values": ["reproduce", "baseline", "failing output"]},
-        {"name": "protects_test_integrity", "type": "contains_any", "values": ["Do not weaken tests", "Do not delete assertions", "Do not weaken"] }
+        {"name": "protects_verification_integrity", "type": "contains_any", "values": ["Verification integrity:"] }
       ]
     },
     {
@@ -69,7 +69,7 @@
       "assertions": [
         {"name": "has_compact_goal_sections", "type": "contains_all", "values": ["/goal", "Read first:", "Constraints:", "Done when:", "Verify with:", "Stop if:", "Final output:"]},
         {"name": "preserves_requested_commands", "type": "contains_all", "values": ["npm test -- auth", "npm run lint"]},
-        {"name": "protects_test_integrity", "type": "contains_any", "values": ["Do not weaken tests", "Do not delete assertions", "Do not weaken"] }
+        {"name": "protects_verification_integrity", "type": "contains_any", "values": ["Verification integrity:"] }
       ]
     },
     {
@@ -82,6 +82,107 @@
         {"name": "has_scope_fuse", "type": "contains_any", "values": ["scope fuse", "multiple independent PR-sized changes", "follow-up PRs"]},
         {"name": "bounds_external_guidance", "type": "contains_any", "values": ["advisory", "external platform", "not guaranteed"]},
         {"name": "does_not_guarantee_trending", "type": "not_contains_any", "values": ["guarantee GitHub Trending", "guaranteed Trending placement", "guarantee trending placement"] }
+      ]
+    }
+  ],
+  "skill_contract_checks": [
+    {
+      "id": "handoff-registers-active-goal-before-execution",
+      "file": "../SKILL.md",
+      "assertions": [
+        {"name": "handoff_mentions_active_goal", "type": "contains_all", "values": ["active goal", "启动这个 goal"]},
+        {"name": "handoff_requires_goal_registration", "type": "contains_any", "values": ["create_goal", "goal-registration"]},
+        {"name": "handoff_requires_completion_after_verify", "type": "contains_all", "values": ["update_goal", "DONE WHEN", "VERIFY"]},
+        {"name": "handoff_handles_missing_runtime_support", "type": "contains_any", "values": ["no active-goal mechanism is available", "运行环境支持"]}
+      ]
+    }
+  ],
+  "fixture_cases": [
+    {
+      "id": "pass-launch-readiness-scope-fuse",
+      "file": "fixtures/pass/launch_readiness_scope_fuse.md",
+      "profile": "auto",
+      "expected_lint_pass": true,
+      "assertions": [
+        {"name": "has_scope_fuse", "type": "contains_any", "values": ["multiple independent PR-sized changes", "follow-up PRs"]},
+        {"name": "does_not_guarantee_external_outcome", "type": "contains_any", "values": ["external outcome", "not guaranteed"]}
+      ]
+    },
+    {
+      "id": "pass-read-only-research",
+      "file": "fixtures/pass/read_only_research.md",
+      "profile": "auto",
+      "expected_lint_pass": true,
+      "assertions": [
+        {"name": "states_read_only", "type": "contains_any", "values": ["read-only", "Do not edit files"]},
+        {"name": "does_not_force_root_cause", "type": "not_contains_any", "values": ["root cause"]}
+      ]
+    },
+    {
+      "id": "pass-xss-output-encoding",
+      "file": "fixtures/pass/xss_output_encoding.md",
+      "profile": "auto",
+      "expected_lint_pass": true,
+      "assertions": [
+        {"name": "mentions_unsafe_sink", "type": "contains_any", "values": ["innerHTML", "unsafe sink"]},
+        {"name": "does_not_require_link_allowlist", "type": "not_contains_any", "values": ["protocol allowlist"]}
+      ]
+    },
+    {
+      "id": "pass-growth-plan-read-only",
+      "file": "fixtures/pass/growth_plan_read_only.md",
+      "profile": "auto",
+      "expected_lint_pass": true,
+      "assertions": [
+        {"name": "external_outcomes_not_guaranteed", "type": "contains_all", "values": ["external outcome targets", "not guaranteed"]},
+        {"name": "has_scope_fuse", "type": "contains_any", "values": ["multiple independent PR-sized changes", "follow-up PRs"]},
+        {"name": "has_manual_platform_blocker", "type": "contains_any", "values": ["repository settings changes requiring owner approval", "manual platform blockers"]}
+      ]
+    },
+    {
+      "id": "fail-fake-context-generic-done",
+      "file": "fixtures/fail/fake_context_generic_done.md",
+      "profile": "auto",
+      "expected_lint_pass": false,
+      "assertions": [
+        {"name": "contains_fake_context", "type": "contains_any", "values": ["Read relevant files"]},
+        {"name": "contains_generic_verify", "type": "contains_any", "values": ["Run tests"]}
+      ]
+    },
+    {
+      "id": "fail-migration-without-dry-run",
+      "file": "fixtures/fail/migration_without_dry_run.md",
+      "profile": "auto",
+      "expected_lint_pass": false,
+      "assertions": [
+        {"name": "missing_dry_run", "type": "not_contains_any", "values": ["dry-run"]}
+      ]
+    },
+    {
+      "id": "fail-read-only-patch",
+      "file": "fixtures/fail/read_only_patch.md",
+      "profile": "auto",
+      "expected_lint_pass": false,
+      "assertions": [
+        {"name": "contains_patch_instruction", "type": "contains_any", "values": ["patch the code"]}
+      ]
+    },
+    {
+      "id": "fail-xss-blacklist-only-link",
+      "file": "fixtures/fail/xss_blacklist_only_link.md",
+      "profile": "auto",
+      "expected_lint_pass": false,
+      "assertions": [
+        {"name": "contains_blacklist_only", "type": "contains_any", "values": ["blacklist-only"]}
+      ]
+    },
+    {
+      "id": "fail-launch-without-scope-fuse",
+      "file": "fixtures/fail/launch_without_scope_fuse.md",
+      "profile": "auto",
+      "expected_lint_pass": false,
+      "assertions": [
+        {"name": "missing_scope_fuse", "type": "not_contains_any", "values": ["multiple independent PR-sized changes", "scope fuse", "follow-up PRs"]}
       ]
     }
   ]

--- a/skills/make-goal/evals/fixtures/fail/fake_context_generic_done.md
+++ b/skills/make-goal/evals/fixtures/fail/fake_context_generic_done.md
@@ -1,0 +1,22 @@
+/goal
+GOAL:
+Fix the app.
+
+CONTEXT:
+- Read relevant files.
+
+CONSTRAINTS:
+- Do not weaken tests.
+
+DONE WHEN:
+- It works.
+
+VERIFY:
+- Run tests.
+
+OUTPUT:
+- Changed files and summary.
+
+STOP RULES:
+- Stop on secrets, production credentials, or destructive operations.
+- Stop after three failed attempts on the same symptom.

--- a/skills/make-goal/evals/fixtures/fail/launch_without_scope_fuse.md
+++ b/skills/make-goal/evals/fixtures/fail/launch_without_scope_fuse.md
@@ -1,0 +1,24 @@
+/goal
+GOAL:
+Complete a launch-readiness pass for GitHub Trending.
+
+CONTEXT:
+- Read `README.md`, `docs/index.html`, and `.github/workflows/catalog.yml`.
+
+CONSTRAINTS:
+- Do not claim GitHub Trending is guaranteed.
+- Do not weaken tests.
+
+DONE WHEN:
+- README, GitHub Pages, metadata, issue hygiene, share copy, and repo settings are all complete.
+
+VERIFY:
+- Run `python3 scripts/validate_data.py`.
+- Capture browser screenshots.
+
+OUTPUT:
+- Changed files, verification output, and manual repository settings steps.
+
+STOP RULES:
+- Stop on secrets, production credentials, destructive operations, or repository settings requiring owner approval.
+- Stop after three failed attempts on the same symptom.

--- a/skills/make-goal/evals/fixtures/fail/migration_without_dry_run.md
+++ b/skills/make-goal/evals/fixtures/fail/migration_without_dry_run.md
@@ -1,0 +1,25 @@
+/goal
+GOAL:
+Add a unique index to `users.email` in the production database.
+
+CONTEXT:
+- Read `migrations/`, `db/schema.sql`, and the current duplicate email report.
+
+CONSTRAINTS:
+- Do not perform destructive production database operations.
+- Include rollback notes and row count evidence.
+- Do not weaken tests.
+
+DONE WHEN:
+- The unique index migration is ready for review and duplicate rows are accounted for.
+
+VERIFY:
+- Run `python3 scripts/check_migrations.py`.
+- Capture row count and duplicate email reports.
+
+OUTPUT:
+- Changed files, migration notes, rollback notes, and verification output.
+
+STOP RULES:
+- Stop on production credentials, destructive operations, or missing database access.
+- Stop after three failed attempts on the same migration failure.

--- a/skills/make-goal/evals/fixtures/fail/read_only_patch.md
+++ b/skills/make-goal/evals/fixtures/fail/read_only_patch.md
@@ -1,0 +1,22 @@
+/goal
+GOAL:
+Investigate why active subscriptions show an empty billing state.
+
+CONTEXT:
+- Read `src/billing/state.ts`, `tests/billing_state.test.ts`, and the failing screenshot.
+
+CONSTRAINTS:
+- This is read-only. Do not edit files.
+
+DONE WHEN:
+- The root cause report includes evidence.
+
+VERIFY:
+- Inspect the named files and capture the root cause evidence.
+
+OUTPUT:
+- Root cause, evidence, and a patch the code recommendation.
+
+STOP RULES:
+- Stop on secrets, production credentials, or destructive operations.
+- Stop after three failed attempts on the same symptom.

--- a/skills/make-goal/evals/fixtures/fail/xss_blacklist_only_link.md
+++ b/skills/make-goal/evals/fixtures/fail/xss_blacklist_only_link.md
@@ -1,0 +1,24 @@
+/goal
+GOAL:
+Fix a frontend XSS risk from user-provided links.
+
+CONTEXT:
+- Read `docs/entry-renderer.js`, `docs/app.js`, and the link rendering tests.
+
+CONSTRAINTS:
+- Use blacklist-only validation for `javascript:` links.
+- Do not weaken tests.
+
+DONE WHEN:
+- User-provided links are filtered.
+
+VERIFY:
+- Run `node --check docs/app.js`.
+- Run the link rendering test.
+
+OUTPUT:
+- Changed files and verification output.
+
+STOP RULES:
+- Stop on secrets, production credentials, or destructive operations.
+- Stop after three failed attempts on the same symptom.

--- a/skills/make-goal/evals/fixtures/pass/growth_plan_read_only.md
+++ b/skills/make-goal/evals/fixtures/pass/growth_plan_read_only.md
@@ -1,0 +1,39 @@
+/goal
+GOAL:
+Produce a source-backed 5000-star growth plan for `awesome-goal-prompts` that defines the smallest credible launch sequence, first PR scope, metrics baseline, and distribution checklist without claiming stars, GitHub Trending placement, or awesome-list acceptance are guaranteed.
+
+CONTEXT:
+- Read `README.md`, `docs/index.html`, `docs/catalog-health.md`, `SOURCES.md`, `CONTRIBUTING.md`, and issue #2.
+- Inspect current GitHub metadata with `gh repo view majiayu000/awesome-goal-prompts --json description,stargazerCount,forkCount,repositoryTopics,homepageUrl,url,createdAt,pushedAt`.
+- Inspect GitHub traffic with `gh api repos/majiayu000/awesome-goal-prompts/traffic/views`, `/traffic/clones`, `/traffic/popular/referrers`, and `/traffic/popular/paths`.
+- Run `npx --yes awesome-lint` and group failures by blocker type.
+
+CONSTRAINTS:
+- Do not edit repository files in this pass; output a report/plan only.
+- Treat 5000 stars, GitHub Trending, and awesome-list acceptance as external outcome targets, not guaranteed done conditions.
+- If this expands into multiple independent PR-sized changes, keep the goal to the smallest growth/readiness plan and list follow-up PRs instead of expanding scope.
+- Do not recommend spam, fake stars, bought traffic, misleading badges, or AI-generated PR submission text.
+- Verification integrity: do not weaken or bypass tests, assertions, lint, typecheck, validation, generated-output checks, screenshots, awesome-lint failures, or external blockers to make the goal pass; fix the root cause or report the blocker.
+
+DONE WHEN:
+- The report states the current baseline: stars, forks, topics, traffic, clone/view ratio, top referrers, top paths, open marketing issue, and validation status.
+- The report diagnoses whether the repo is currently ready to pursue 5000 stars and identifies the top 3 blockers, ordered by impact and backed by evidence.
+- The report defines a 3-phase path: trust/readiness, launch/distribution, retention/community.
+- The report gives a first PR scope that can be executed independently and verified.
+
+VERIFY:
+- Capture fresh `gh repo view` output for repository metadata.
+- Capture fresh GitHub traffic API output or exact permission blockers.
+- Capture fresh `npx --yes awesome-lint` output summarized by blocker bucket.
+- Run `python3 scripts/validate_data.py`, `python3 scripts/validate_metadata.py`, and `python3 scripts/evaluate_search.py`.
+
+OUTPUT:
+- Concise growth plan with baseline, blockers, launch sequence, first PR scope, distribution checklist, metric cadence, manual platform blockers, and remaining risks.
+- Changed files: none.
+- Explicit decision on whether issue #2 is ready now, blocked until 2026-06-13, or blocked by awesome-lint/category fit.
+
+STOP RULES:
+- Stop on secrets, production credentials, destructive operations, force push, direct main push, unavailable traffic permissions, or repository settings changes requiring owner approval.
+- Stop if awesome-list requirements conflict with the repository's real product shape and document the mismatch instead of forcing compliance.
+- Stop if the plan would require fake engagement, paid stars, misleading claims, automated social posting, or external submission without approval.
+- Stop after three failed attempts to satisfy the same lint/submission blocker and revisit whether awesome-list submission is the right channel.

--- a/skills/make-goal/evals/fixtures/pass/launch_readiness_scope_fuse.md
+++ b/skills/make-goal/evals/fixtures/pass/launch_readiness_scope_fuse.md
@@ -1,0 +1,30 @@
+/goal
+GOAL:
+Complete the smallest PR-ready launch-readiness pass for `awesome-goal-prompts` without treating GitHub Trending placement as a guaranteed outcome.
+
+CONTEXT:
+- Read `AGENTS.md`, `README.md`, `docs/index.html`, `docs/app.js`, and issue #2 before editing.
+- Establish the current branch state with `git status --short --branch`.
+
+CONSTRAINTS:
+- Keep scope limited to launch readiness; do not add catalog entries or redesign unrelated UI.
+- If the work expands into multiple independent PR-sized changes, keep this goal to the smallest launch-readiness pass and list follow-up PRs instead of expanding scope.
+- Treat GitHub Trending as an external outcome, not guaranteed.
+- Verification integrity: do not weaken or bypass tests, assertions, lint, typecheck, validation, generated-output checks, screenshots, or external blockers to make the goal pass; fix the root cause or report the blocker.
+
+DONE WHEN:
+- README and Pages first viewport clearly describe the project, credible counts, and how to try a goal.
+- Repository settings that require owner approval are documented as manual steps with exact steps.
+
+VERIFY:
+- Run `python3 scripts/validate_data.py`.
+- Run `python3 scripts/evaluate_search.py`.
+- Capture desktop and mobile screenshots, or report the exact blocker if browser evidence cannot run.
+
+OUTPUT:
+- Changed files, key decisions, verification output, manual settings blockers, remaining risk, and follow-up PRs.
+
+STOP RULES:
+- Stop on secrets, production credentials, destructive operations, or repository settings changes requiring owner approval.
+- Stop after three failed attempts on the same symptom and revisit the root-cause hypothesis.
+- Do not mark complete until the current state has been checked against DONE WHEN.

--- a/skills/make-goal/evals/fixtures/pass/read_only_research.md
+++ b/skills/make-goal/evals/fixtures/pass/read_only_research.md
@@ -1,0 +1,26 @@
+/goal
+GOAL:
+Produce a read-only assessment of whether `docs/styles.css` matches the existing catalog typography and spacing conventions.
+
+CONTEXT:
+- Read `docs/styles.css`, `docs/index.html`, and `docs/assets/catalog-browser.png`.
+- Compare against the current local first viewport screenshot if one exists.
+
+CONSTRAINTS:
+- This is read-only. Do not edit files, run formatters, or stage changes.
+- Separate observed evidence from design preferences.
+
+DONE WHEN:
+- The final report lists typography and spacing findings with evidence and file references.
+- Changed files are none.
+
+VERIFY:
+- Inspect the named files and report exact selectors or screenshot observations used as evidence.
+
+OUTPUT:
+- Findings, evidence, remaining uncertainty, and changed files: none.
+
+STOP RULES:
+- Stop on missing screenshots only for screenshot-specific claims; continue with file-based evidence.
+- Stop after three failed attempts to locate a referenced selector.
+- Stop if secrets, production access, credentials, or destructive operations are required.

--- a/skills/make-goal/evals/fixtures/pass/xss_output_encoding.md
+++ b/skills/make-goal/evals/fixtures/pass/xss_output_encoding.md
@@ -1,0 +1,28 @@
+/goal
+GOAL:
+Fix an XSS risk in Markdown rendering by replacing unsafe `innerHTML` usage with safe DOM construction or output encoding.
+
+CONTEXT:
+- Read `docs/entry-renderer.js`, `docs/app.js`, and the existing browser smoke test notes before editing.
+- Use the current rendering behavior as the baseline.
+
+CONSTRAINTS:
+- Do not introduce unsafe HTML sinks, `eval`, shell string execution, or string-built queries.
+- Preserve keyboard behavior and copy/verify controls.
+- Verification integrity: do not weaken or bypass tests, assertions, lint, typecheck, validation, generated-output checks, screenshots, or external blockers to make the goal pass; fix the root cause or report the blocker.
+
+DONE WHEN:
+- User-controlled Markdown no longer reaches `innerHTML` or another unsafe sink.
+- Existing entry rendering behavior remains intact for safe content.
+
+VERIFY:
+- Run `node --check docs/app.js`.
+- Capture a browser smoke result or test result that exercises malicious Markdown and normal Markdown.
+
+OUTPUT:
+- Changed files, unsafe sink removed, verification output, and remaining risk.
+
+STOP RULES:
+- Stop if the fix requires changing trusted content policy or product rendering semantics.
+- Stop on secrets, production credentials, destructive operations, or repository settings changes.
+- Stop after three failed attempts on the same rendering failure.

--- a/skills/make-goal/scripts/lint_goal.py
+++ b/skills/make-goal/scripts/lint_goal.py
@@ -3,14 +3,15 @@
 
 This script checks deterministic properties that are easy to regress:
 required goal sections, fresh verification language, stop rules, and
-profile-specific safety requirements for read-only, data migration, XSS, and
-clarify-first outputs.
+profile-specific safety requirements for read-only, data migration, XSS,
+launch-readiness, and clarify-first outputs.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -43,6 +44,88 @@ VAGUE_PHRASES = [
     "use your best judgment",
 ]
 
+PROFILE_NAMES = [
+    "general",
+    "compact",
+    "read-only",
+    "data-migration",
+    "security-xss",
+    "launch-readiness",
+    "clarify",
+]
+
+GENERIC_CONTEXT_PHRASES = [
+    "read relevant files",
+    "inspect the repo",
+    "read the codebase",
+    "look around",
+    "understand the project",
+]
+
+GENERIC_DONE_PHRASES = [
+    "it works",
+    "works",
+    "done",
+    "complete",
+    "completed",
+    "fixed",
+    "all good",
+]
+
+GENERIC_VERIFY_PHRASES = [
+    "run tests",
+    "run the tests",
+    "test it",
+    "verify it works",
+    "make sure it works",
+]
+
+GOAL_ACTION_TERMS = [
+    "fix",
+    "add",
+    "refactor",
+    "redesign",
+    "migrate",
+    "deploy",
+    "rewrite",
+    "optimize",
+    "build",
+    "implement",
+    "update",
+    "document",
+]
+
+LINK_OR_NAVIGATION_TERMS = [
+    "user-provided link",
+    "user provided link",
+    "href",
+    "src",
+    "url",
+    "link",
+    "javascript:",
+    "window.open",
+    "location.href",
+    "navigation",
+]
+
+INVESTIGATION_TERMS = [
+    "debug",
+    "root cause",
+    "why ",
+    "empty state",
+]
+
+READ_ONLY_REPORT_TERMS = [
+    "readiness",
+    "growth",
+    "launch",
+    "review",
+    "assessment",
+    "report",
+    "plan",
+    "strategy",
+]
+
 
 @dataclass
 class Check:
@@ -65,6 +148,16 @@ def contains_any(text: str, terms: list[str]) -> bool:
 def contains_all(text: str, terms: list[str]) -> bool:
     lowered = normalize(text)
     return all(term.lower() in lowered for term in terms)
+
+
+def unique(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item not in seen:
+            result.append(item)
+            seen.add(item)
+    return result
 
 
 def section_positions(text: str) -> dict[str, int]:
@@ -119,19 +212,99 @@ def recommends_blacklist_only(text: str) -> bool:
     return not any(term in lowered for term in avoidance_terms)
 
 
-def infer_profile(text: str) -> str:
+def has_link_or_navigation_context(text: str) -> bool:
+    return contains_any(text, LINK_OR_NAVIGATION_TERMS)
+
+
+def is_investigation_context(text: str) -> bool:
+    lowered = normalize(text)
+    if contains_any(lowered, ["root cause", "debug", "why ", "empty state"]):
+        return True
+    if contains_any(lowered, ["investigate", "diagnose", "diagnosis", "diagnoses"]):
+        fault_terms = ["bug", "crash", "error", "exception", "failing", "failure", "broken", "empty state"]
+        report_terms = [term for term in READ_ONLY_REPORT_TERMS if term not in {"report", "assessment"}]
+        return contains_any(lowered, fault_terms) and not contains_any(lowered, report_terms)
+    return False
+
+
+def has_concrete_context(context: str) -> bool:
+    lowered = normalize(context)
+    if contains_any(lowered, GENERIC_CONTEXT_PHRASES) and len(lowered.split()) < 30:
+        return False
+    concrete_patterns = [
+        r"`[^`]+`",
+        r"\b[A-Za-z0-9_.-]+\.(md|py|js|ts|tsx|jsx|json|toml|yml|yaml|html|css|go|rs|java|rb|php)\b",
+        r"\b(issue|pr|pull request)\s*#?\d+\b",
+        r"\bhttps?://",
+        r"\b(test|lint|build|typecheck|pytest|npm|pnpm|yarn|cargo|go test|node --check)\b",
+        r"\b(log|screenshot|trace|stack|baseline|report|workflow)\b",
+    ]
+    return any(re.search(pattern, context, re.IGNORECASE) for pattern in concrete_patterns)
+
+
+def is_generic_done_when(done_when: str) -> bool:
+    stripped = " ".join(done_when.lower().strip(" .:-`").split())
+    if stripped in GENERIC_DONE_PHRASES:
+        return True
+    return len(stripped.split()) <= 5 and contains_any(stripped, GENERIC_DONE_PHRASES)
+
+
+def is_generic_verify(verify: str) -> bool:
+    stripped = " ".join(verify.lower().strip(" .:-`").split())
+    if stripped in GENERIC_VERIFY_PHRASES:
+        return True
+    if len(stripped.split()) <= 6 and contains_any(stripped, GENERIC_VERIFY_PHRASES):
+        return True
+    return False
+
+
+def looks_like_backlog_goal(goal: str) -> bool:
+    lowered = normalize(goal)
+    if contains_any(lowered, ["backlog", "everything", "all bugs", "all issues"]):
+        return True
+    action_count = sum(1 for term in GOAL_ACTION_TERMS if re.search(rf"\b{re.escape(term)}\b", lowered))
+    has_many_connectors = lowered.count(",") >= 2 or lowered.count(" and ") >= 2
+    return action_count >= 3 and has_many_connectors
+
+
+def infer_profiles(text: str) -> list[str]:
     lowered = normalize(text)
     if "/goal" not in lowered and contains_any(lowered, ["primary goal", "one finish line", "what is the one"]):
-        return "clarify"
-    if has_read_only_boundary(lowered):
-        return "read-only"
+        return ["clarify"]
+
+    profiles: list[str] = []
     if is_compact_goal(lowered):
-        return "compact"
-    if contains_any(lowered, ["xss", "user-provided link", "javascript:", "innerhtml", "unsafe html"]):
-        return "security-xss"
+        profiles.append("compact")
+    else:
+        profiles.append("general")
+
     if contains_any(lowered, ["production database", "unique index", "users.email", "migration", "ddl"]):
-        return "data-migration"
-    return "general"
+        profiles.append("data-migration")
+    if contains_any(lowered, ["xss", "innerhtml", "unsafe html"]) and (
+        has_link_or_navigation_context(lowered) or contains_any(lowered, ["innerhtml", "unsafe html", "unsafe sink"])
+    ):
+        profiles.append("security-xss")
+    if has_read_only_boundary(lowered):
+        profiles.append("read-only")
+    if contains_any(lowered, ["launch-readiness", "launch readiness", "release-prep", "release prep", "trending", "roadmap"]):
+        profiles.append("launch-readiness")
+    return unique(profiles)
+
+
+def parse_profiles(profile: str) -> list[str]:
+    if profile == "auto":
+        return ["auto"]
+    profiles = [part.strip() for part in profile.split(",") if part.strip()]
+    unknown = [name for name in profiles if name not in PROFILE_NAMES]
+    if unknown:
+        raise SystemExit(f"unknown profile: {', '.join(unknown)}")
+    if "clarify" in profiles and len(profiles) > 1:
+        raise SystemExit("clarify cannot be combined with other profiles")
+    if "general" in profiles and "compact" in profiles:
+        raise SystemExit("general and compact cannot be combined")
+    if "general" not in profiles and "compact" not in profiles and "clarify" not in profiles:
+        profiles.insert(0, "general")
+    return unique(profiles)
 
 
 def check_contract_shape(text: str) -> list[Check]:
@@ -199,9 +372,48 @@ def check_contract_shape(text: str) -> list[Check]:
     )
     checks.append(
         Check(
+            "goal_not_backlog",
+            "error",
+            not looks_like_backlog_goal(goal),
+            "GOAL should describe one primary objective, not several independent backlog items.",
+            goal[:180],
+        )
+    )
+    context = extract_section(text, "CONTEXT:")
+    checks.append(
+        Check(
+            "context_has_concrete_sources",
+            "error",
+            has_concrete_context(context),
+            "CONTEXT should name concrete files, issues, logs, commands, screenshots, URLs, or baselines.",
+            context[:220],
+        )
+    )
+    done_when = extract_section(text, "DONE WHEN:")
+    checks.append(
+        Check(
+            "done_when_not_generic",
+            "error",
+            not is_generic_done_when(done_when),
+            "DONE WHEN should be mechanically checkable, not a generic completion phrase.",
+            done_when[:180],
+        )
+    )
+    verify = extract_section(text, "VERIFY:")
+    checks.append(
+        Check(
+            "verify_not_generic",
+            "error",
+            not is_generic_verify(verify),
+            "VERIFY should name a concrete command, report, screenshot, artifact, or exact blocker.",
+            verify[:180],
+        )
+    )
+    checks.append(
+        Check(
             "verify_requires_fresh_evidence",
             "error",
-            contains_any(extract_section(text, "VERIFY:"), ["run ", "capture", "fresh", "current session", "screenshot", "report", "inspect", "if verification cannot run", "stop and report"]),
+            contains_any(verify, ["run ", "capture", "fresh", "current session", "screenshot", "report", "inspect", "if verification cannot run", "stop and report"]),
             "VERIFY should require fresh command output, report, screenshot, inspection, or an explicit blocker.",
         )
     )
@@ -226,10 +438,10 @@ def check_contract_shape(text: str) -> list[Check]:
     )
     checks.append(
         Check(
-            "protects_test_integrity",
+            "protects_verification_integrity",
             "warn",
-            contains_any(text, ["do not weaken tests", "do not delete assertions", "test integrity", "do not weaken lint"]),
-            "Goal should protect tests and assertions when implementation or verification is involved.",
+            "verification integrity:" in normalize(text),
+            "Goals with implementation or verification work should include the canonical Verification integrity constraint.",
         )
     )
     return checks
@@ -317,7 +529,8 @@ def check_compact_shape(text: str) -> list[Check]:
 
 
 def check_read_only(text: str) -> list[Check]:
-    return [
+    requires_root_cause = is_investigation_context(text)
+    checks = [
         Check(
             "read_only_boundary",
             "error",
@@ -331,12 +544,22 @@ def check_read_only(text: str) -> list[Check]:
             "Read-only goals must not instruct the agent to patch implementation code.",
         ),
         Check(
-            "root_cause_evidence",
+            "read_only_requires_evidence",
             "error",
-            contains_all(text, ["root cause", "evidence"]),
-            "Read-only investigation goals should require a root-cause report with evidence.",
+            contains_any(text, ["evidence", "findings", "report", "assessment", "summary"]),
+            "Read-only goals should require evidence, findings, a report, or an assessment.",
         ),
     ]
+    checks.append(
+        Check(
+            "root_cause_evidence",
+            "error",
+            (not requires_root_cause) or contains_all(text, ["root cause", "evidence"]),
+            "Read-only investigation/debug goals should require a root-cause report with evidence.",
+            "not an investigation/debug goal" if not requires_root_cause else "",
+        )
+    )
+    return checks
 
 
 def check_data_migration(text: str) -> list[Check]:
@@ -369,12 +592,14 @@ def check_data_migration(text: str) -> list[Check]:
 
 
 def check_security_xss(text: str) -> list[Check]:
+    link_context = has_link_or_navigation_context(text)
     return [
         Check(
             "requires_protocol_allowlist",
             "error",
-            contains_any(text, ["protocol allowlist", "protocol whitelist", "allowlist"]),
-            "XSS link goals must require protocol allowlist validation.",
+            (not link_context) or contains_any(text, ["protocol allowlist", "protocol whitelist", "allowlist"]),
+            "Link or navigation XSS goals must require protocol allowlist validation.",
+            "not a link/navigation XSS goal" if not link_context else "",
         ),
         Check(
             "rejects_blacklist_only",
@@ -393,6 +618,29 @@ def check_security_xss(text: str) -> list[Check]:
             "error",
             contains_any(text, ["browser", "playwright", "smoke", "test"]),
             "XSS link goals should require tests or browser smoke evidence.",
+        ),
+    ]
+
+
+def check_launch_readiness(text: str) -> list[Check]:
+    return [
+        Check(
+            "launch_scope_fuse",
+            "error",
+            contains_any(text, ["scope fuse", "multiple independent pr-sized changes", "follow-up prs", "smallest launch-readiness pass"]),
+            "Launch/readiness goals should include a scope fuse for multiple independent PR-sized changes.",
+        ),
+        Check(
+            "external_outcomes_not_guaranteed",
+            "error",
+            contains_any(text, ["not guaranteed", "external outcome", "do not claim", "do not imply", "advisory"]),
+            "Launch/readiness goals should not guarantee external outcomes such as trending, ranking, traffic, or approval.",
+        ),
+        Check(
+            "manual_platform_steps",
+            "error",
+            contains_any(text, ["manual", "owner approval", "repository settings", "settings access", "exact steps"]),
+            "Platform or repository settings that require owner access should be documented as manual steps or blockers.",
         ),
     ]
 
@@ -427,24 +675,24 @@ def check_clarify(text: str) -> list[Check]:
 
 
 def lint(text: str, profile: str) -> tuple[str, list[Check]]:
-    selected = infer_profile(text) if profile == "auto" else profile
+    selected_profiles = infer_profiles(text) if profile == "auto" else parse_profiles(profile)
     checks: list[Check] = []
-    if selected == "clarify":
+    if "clarify" in selected_profiles:
         checks.extend(check_clarify(text))
-        return selected, checks
-    if selected == "compact":
+        return "+".join(selected_profiles), checks
+    if "compact" in selected_profiles:
         checks.extend(check_compact_shape(text))
-        return selected, checks
-    checks.extend(check_contract_shape(text))
-    if selected == "read-only":
+    else:
+        checks.extend(check_contract_shape(text))
+    if "read-only" in selected_profiles:
         checks.extend(check_read_only(text))
-    elif selected == "data-migration":
+    if "data-migration" in selected_profiles:
         checks.extend(check_data_migration(text))
-    elif selected == "security-xss":
+    if "security-xss" in selected_profiles:
         checks.extend(check_security_xss(text))
-    elif selected != "general":
-        raise SystemExit(f"unknown profile: {selected}")
-    return selected, checks
+    if "launch-readiness" in selected_profiles:
+        checks.extend(check_launch_readiness(text))
+    return "+".join(selected_profiles), checks
 
 
 def print_text(path: Path, profile: str, checks: list[Check]) -> None:
@@ -471,9 +719,11 @@ def main() -> int:
     parser.add_argument("path", type=Path, help="Markdown/text file to lint")
     parser.add_argument(
         "--profile",
-        choices=["auto", "general", "compact", "read-only", "data-migration", "security-xss", "clarify"],
         default="auto",
-        help="Lint profile. auto infers from the file content.",
+        help=(
+            "Lint profile. Use auto, one profile, or comma-separated profiles "
+            f"from: {', '.join(PROFILE_NAMES)}."
+        ),
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     parser.add_argument("--strict-warnings", action="store_true", help="Treat warnings as failures")

--- a/skills/make-goal/scripts/lint_goal.py
+++ b/skills/make-goal/scripts/lint_goal.py
@@ -25,6 +25,15 @@ FULL_SECTIONS = [
     "STOP RULES:",
 ]
 
+COMPACT_SECTIONS = [
+    "Read first:",
+    "Constraints:",
+    "Done when:",
+    "Verify with:",
+    "Stop if:",
+    "Final output:",
+]
+
 VAGUE_PHRASES = [
     "make it better",
     "fix everything",
@@ -63,8 +72,13 @@ def section_positions(text: str) -> dict[str, int]:
     return {section: lowered.find(section.lower()) for section in FULL_SECTIONS}
 
 
-def extract_section(text: str, section: str) -> str:
-    positions = section_positions(text)
+def positions_for(text: str, sections: list[str]) -> dict[str, int]:
+    lowered = normalize(text)
+    return {section: lowered.find(section.lower()) for section in sections}
+
+
+def extract_section(text: str, section: str, sections: list[str] | None = None) -> str:
+    positions = positions_for(text, sections or FULL_SECTIONS)
     start = positions.get(section, -1)
     if start < 0:
         return ""
@@ -78,16 +92,45 @@ def extract_section(text: str, section: str) -> str:
     return text[start:end].strip()
 
 
+def has_read_only_boundary(text: str) -> bool:
+    return contains_any(text, ["read-only", "do not edit files", "do not modify", "changed files: `none`", "changed files: none"])
+
+
+def is_compact_goal(text: str) -> bool:
+    lowered = normalize(text)
+    return "/goal" in lowered and all(section.lower() in lowered for section in COMPACT_SECTIONS)
+
+
+def recommends_blacklist_only(text: str) -> bool:
+    lowered = normalize(text)
+    if "blacklist-only" not in lowered and "blacklist only" not in lowered:
+        return False
+    avoidance_terms = [
+        "do not rely on blacklist",
+        "do not use blacklist",
+        "do not use blacklist-only",
+        "not rely on blacklist",
+        "avoid blacklist",
+        "avoid blacklist-only",
+        "instead of blacklist",
+        "not blacklist-only",
+        "never rely on blacklist",
+    ]
+    return not any(term in lowered for term in avoidance_terms)
+
+
 def infer_profile(text: str) -> str:
     lowered = normalize(text)
     if "/goal" not in lowered and contains_any(lowered, ["primary goal", "one finish line", "what is the one"]):
         return "clarify"
+    if has_read_only_boundary(lowered):
+        return "read-only"
+    if is_compact_goal(lowered):
+        return "compact"
     if contains_any(lowered, ["xss", "user-provided link", "javascript:", "innerhtml", "unsafe html"]):
         return "security-xss"
     if contains_any(lowered, ["production database", "unique index", "users.email", "migration", "ddl"]):
         return "data-migration"
-    if contains_any(lowered, ["read-only", "do not edit files", "changed files: `none`", "changed files: none"]):
-        return "read-only"
     return "general"
 
 
@@ -113,13 +156,14 @@ def check_contract_shape(text: str) -> list[Check]:
         )
     )
     present_positions = [positions[section] for section in FULL_SECTIONS if positions[section] >= 0]
-    ordered = present_positions == sorted(present_positions)
+    ordered = not missing and present_positions == sorted(present_positions)
     checks.append(
         Check(
             "sections_in_order",
             "error",
             ordered,
             "Full goal sections should appear in the standard order.",
+            "cannot check order until all sections are present" if missing else "",
         )
     )
     empty_sections = [
@@ -127,13 +171,20 @@ def check_contract_shape(text: str) -> list[Check]:
         for section in FULL_SECTIONS
         if positions.get(section, -1) >= 0 and not extract_section(text, section)
     ]
+    nonempty = not missing and not empty_sections
     checks.append(
         Check(
             "sections_nonempty",
             "error",
-            not empty_sections,
+            nonempty,
             "Each full goal section should contain concrete content.",
-            ", ".join(empty_sections) if empty_sections else "all present sections have content",
+            (
+                "missing: " + ", ".join(missing)
+                if missing
+                else ", ".join(empty_sections)
+                if empty_sections
+                else "all present sections have content"
+            ),
         )
     )
     goal = extract_section(text, "GOAL:")
@@ -184,12 +235,93 @@ def check_contract_shape(text: str) -> list[Check]:
     return checks
 
 
+def check_compact_shape(text: str) -> list[Check]:
+    checks: list[Check] = []
+    lowered = normalize(text)
+    checks.append(
+        Check(
+            "has_goal_command",
+            "error",
+            "/goal" in lowered,
+            "Compact goals should include the /goal command.",
+        )
+    )
+    positions = positions_for(text, COMPACT_SECTIONS)
+    missing = [section for section, pos in positions.items() if pos < 0]
+    checks.append(
+        Check(
+            "has_compact_sections",
+            "error",
+            not missing,
+            "Compact goals must include Read first, Constraints, Done when, Verify with, Stop if, and Final output.",
+            ", ".join(missing) if missing else "all compact sections present",
+        )
+    )
+    present_positions = [positions[section] for section in COMPACT_SECTIONS if positions[section] >= 0]
+    checks.append(
+        Check(
+            "compact_sections_in_order",
+            "error",
+            not missing and present_positions == sorted(present_positions),
+            "Compact goal sections should appear in the standard order.",
+            "cannot check order until all compact sections are present" if missing else "",
+        )
+    )
+    empty_sections = [
+        section
+        for section in COMPACT_SECTIONS
+        if positions.get(section, -1) >= 0 and not extract_section(text, section, COMPACT_SECTIONS)
+    ]
+    checks.append(
+        Check(
+            "compact_sections_nonempty",
+            "error",
+            not missing and not empty_sections,
+            "Each compact goal section should contain concrete content.",
+            (
+                "missing: " + ", ".join(missing)
+                if missing
+                else ", ".join(empty_sections)
+                if empty_sections
+                else "all compact sections have content"
+            ),
+        )
+    )
+    goal_line = next((line for line in text.splitlines() if line.lower().startswith("/goal")), "")
+    checks.append(
+        Check(
+            "goal_not_vague",
+            "error",
+            bool(goal_line.strip()) and not contains_any(goal_line, VAGUE_PHRASES),
+            "Compact /goal line must contain a specific measurable goal.",
+            goal_line[:180],
+        )
+    )
+    checks.append(
+        Check(
+            "compact_verify_present",
+            "error",
+            contains_any(extract_section(text, "Verify with:", COMPACT_SECTIONS), ["run ", "command", "report", "screenshot", "evidence", "test", "lint", "verify"]),
+            "Compact goals should name verification evidence.",
+        )
+    )
+    checks.append(
+        Check(
+            "compact_stop_rules_present",
+            "error",
+            contains_any(extract_section(text, "Stop if:", COMPACT_SECTIONS), ["missing", "destructive", "production", "three failed", "3 failed", "unclear"]),
+            "Compact goals should include meaningful stop conditions.",
+        )
+    )
+    return checks
+
+
 def check_read_only(text: str) -> list[Check]:
     return [
         Check(
             "read_only_boundary",
             "error",
-            contains_any(text, ["read-only", "do not edit files", "do not modify", "changed files: `none`", "changed files: none"]),
+            has_read_only_boundary(text),
             "Read-only goals must explicitly forbid edits.",
         ),
         Check(
@@ -247,7 +379,7 @@ def check_security_xss(text: str) -> list[Check]:
         Check(
             "rejects_blacklist_only",
             "error",
-            contains_any(text, ["do not rely on blacklist", "not rely on blacklist", "blacklist-only", "allowlist"]),
+            not recommends_blacklist_only(text),
             "XSS link goals should avoid blacklist-only validation.",
         ),
         Check(
@@ -300,6 +432,9 @@ def lint(text: str, profile: str) -> tuple[str, list[Check]]:
     if selected == "clarify":
         checks.extend(check_clarify(text))
         return selected, checks
+    if selected == "compact":
+        checks.extend(check_compact_shape(text))
+        return selected, checks
     checks.extend(check_contract_shape(text))
     if selected == "read-only":
         checks.extend(check_read_only(text))
@@ -336,7 +471,7 @@ def main() -> int:
     parser.add_argument("path", type=Path, help="Markdown/text file to lint")
     parser.add_argument(
         "--profile",
-        choices=["auto", "general", "read-only", "data-migration", "security-xss", "clarify"],
+        choices=["auto", "general", "compact", "read-only", "data-migration", "security-xss", "clarify"],
         default="auto",
         help="Lint profile. auto infers from the file content.",
     )

--- a/skills/make-goal/scripts/run_evals.py
+++ b/skills/make-goal/scripts/run_evals.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Run deterministic make-goal eval fixtures.
+
+The skill still needs human or model review for semantic quality. These evals
+only guard regressions that should be mechanically catchable: section shape,
+profile safety checks, and known negative cases.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lint_goal import Check, lint
+
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+EVALS_DIR = SKILL_ROOT / "evals"
+EVALS_PATH = EVALS_DIR / "evals.json"
+
+
+@dataclass
+class CaseResult:
+    name: str
+    passed: bool
+    detail: str
+
+
+def assertion_passes(text: str, assertion: dict[str, Any]) -> bool:
+    kind = assertion["type"]
+    values = assertion.get("values", [])
+    if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+        raise ValueError(f"assertion {assertion.get('name', '<unnamed>')} values must be strings")
+    lowered = text.lower()
+    lowered_values = [value.lower() for value in values]
+    if kind == "contains_all":
+        return all(value in lowered for value in lowered_values)
+    if kind == "contains_any":
+        return any(value in lowered for value in lowered_values)
+    if kind == "not_contains_any":
+        return not any(value in lowered for value in lowered_values)
+    raise ValueError(f"unknown assertion type: {kind}")
+
+
+def validate_prompt_eval_specs(data: dict[str, Any]) -> list[CaseResult]:
+    results: list[CaseResult] = []
+    for item in data.get("evals", []):
+        name = f"prompt-spec:{item.get('id', '<missing-id>')}"
+        assertions = item.get("assertions", [])
+        missing = [
+            field
+            for field in ["id", "prompt", "expected_output", "files", "assertions"]
+            if field not in item
+        ]
+        bad_assertions = [
+            assertion.get("name", "<unnamed>")
+            for assertion in assertions
+            if assertion.get("type") not in {"contains_all", "contains_any", "not_contains_any"}
+            or not isinstance(assertion.get("values"), list)
+        ]
+        if missing or bad_assertions:
+            detail = []
+            if missing:
+                detail.append(f"missing fields: {', '.join(missing)}")
+            if bad_assertions:
+                detail.append(f"bad assertions: {', '.join(bad_assertions)}")
+            results.append(CaseResult(name, False, "; ".join(detail)))
+        else:
+            results.append(CaseResult(name, True, f"{len(assertions)} assertions defined"))
+    return results
+
+
+def run_skill_contract_check(case: dict[str, Any]) -> CaseResult:
+    case_id = case["id"]
+    path = EVALS_DIR / case["file"]
+    text = path.read_text(encoding="utf-8")
+    assertion_failures = [
+        assertion["name"]
+        for assertion in case.get("assertions", [])
+        if not assertion_passes(text, assertion)
+    ]
+    passed = not assertion_failures
+    detail = f"{len(case.get('assertions', []))} assertions checked"
+    if assertion_failures:
+        detail += f" assertion_failures={','.join(assertion_failures)}"
+    return CaseResult(f"skill-contract:{case_id}", passed, detail)
+
+
+def lint_passed(checks: list[Check], strict_warnings: bool) -> bool:
+    failed_errors = [check for check in checks if not check.passed and check.severity == "error"]
+    failed_warnings = [check for check in checks if not check.passed and check.severity == "warn"]
+    return not failed_errors and not (strict_warnings and failed_warnings)
+
+
+def run_fixture(case: dict[str, Any]) -> CaseResult:
+    case_id = case["id"]
+    path = EVALS_DIR / case["file"]
+    text = path.read_text(encoding="utf-8")
+    profile = case.get("profile", "auto")
+    strict_warnings = bool(case.get("strict_warnings", False))
+    expected_lint_pass = bool(case.get("expected_lint_pass", True))
+    selected_profile, checks = lint(text, profile)
+    actual_lint_pass = lint_passed(checks, strict_warnings)
+    assertion_failures = [
+        assertion["name"]
+        for assertion in case.get("assertions", [])
+        if not assertion_passes(text, assertion)
+    ]
+    failed_checks = [
+        check.id
+        for check in checks
+        if not check.passed and (check.severity == "error" or strict_warnings)
+    ]
+    passed = actual_lint_pass == expected_lint_pass and not assertion_failures
+    detail = (
+        f"profile={selected_profile} expected_lint_pass={expected_lint_pass} "
+        f"actual_lint_pass={actual_lint_pass}"
+    )
+    if failed_checks:
+        detail += f" failed_checks={','.join(failed_checks)}"
+    if assertion_failures:
+        detail += f" assertion_failures={','.join(assertion_failures)}"
+    return CaseResult(f"fixture:{case_id}", passed, detail)
+
+
+def main() -> int:
+    data = json.loads(EVALS_PATH.read_text(encoding="utf-8"))
+    results = validate_prompt_eval_specs(data)
+    for case in data.get("skill_contract_checks", []):
+        results.append(run_skill_contract_check(case))
+    for case in data.get("fixture_cases", []):
+        results.append(run_fixture(case))
+
+    failures = [result for result in results if not result.passed]
+    for result in results:
+        status = "PASS" if result.passed else "FAIL"
+        print(f"{status} {result.name} - {result.detail}")
+
+    print(f"summary: {len(results) - len(failures)}/{len(results)} eval checks passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add executable make-goal fixture evals and wire them into the catalog CI workflow.
- Upgrade `lint_goal.py` from single-profile keyword checks to composable profiles, stronger structural checks, launch-readiness checks, and less brittle read-only/XSS detection.
- Add pass/fail fixtures for launch scope fuse, read-only research, XSS output encoding, 5000-star growth-readiness, fake context, generic done/verify, missing migration `dry-run`, read-only patch instructions, blacklist-only XSS, and launch scope drift.
- Update `SKILL.md` to prefer compact/direct handling for tiny tasks, require canonical `Verification integrity:` constraints, distinguish AGENTS/CLAUDE instruction semantics, and register active goals before execution when the runtime supports it.

## Verification

- `python3 -m json.tool skills/make-goal/evals/evals.json`
- `python3 -m py_compile skills/make-goal/scripts/lint_goal.py skills/make-goal/scripts/run_evals.py`
- `python3 skills/make-goal/scripts/run_evals.py` → 17/17 eval checks passed
- `python3 scripts/validate_data.py` → 314 entries, 7 recipes, 32 categories
- `python3 scripts/generate_examples.py`
- `python3 scripts/validate_metadata.py` → 114 source-backed, 200 seed patterns
- `python3 scripts/generate_catalog_health.py`
- `python3 scripts/evaluate_search.py` → 18/18 search eval cases passed
- `node --check docs/app.js`
- `git diff --check`
