### PR TITLE
Add growth playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ First example — [Auth Tests And Lint Clean](prompts/source-backed-goals.md#cla
 
 **Expected outcome:** the agent keeps working until the auth tests pass and lint is clean, then stops only after pasting the passing command output as evidence. If it cannot reach that state, the stop rules tell it to report instead of editing further.
 
+## Contribute A Goal In 5 Minutes
+
+1. Find a thin category or missing rescue pattern in the [catalog browser](https://majiayu000.github.io/awesome-goal-prompts/) or [catalog health report](docs/catalog-health.md).
+2. Draft the contract with [skills/make-goal/](skills/make-goal/) and its [catalog contribution reference](skills/make-goal/references/catalog-contribution.md).
+3. Add the entry through [CONTRIBUTING.md](CONTRIBUTING.md): edit `data/source/entries.toml`, keep public provenance for source-backed examples, regenerate, and run the validation commands.
+
 ## Why This Exists
 
 Most prompt lists stop at catchy instructions. This catalog is for the moment after an agent starts drifting: the task is real, the repo has constraints, and "try harder" is not enough. Each contract gives the agent a narrow job, required context, explicit boundaries, proof, and stop rules.
@@ -57,11 +63,13 @@ The provenance-backed library stays below as the primary reference catalog.
 ## Contents
 
 - [Try It In 60 Seconds](#try-it-in-60-seconds)
+- [Contribute A Goal In 5 Minutes](#contribute-a-goal-in-5-minutes)
 - [Why This Exists](#why-this-exists)
 - [Start With Ten Rescue Prompts](#start-with-ten-rescue-prompts)
 - [Source-Backed Catalog](#source-backed-catalog)
 - [How To Write A Good Goal](#how-to-write-a-good-goal)
 - [Catalog Health](#catalog-health)
+- [Growth Playbook](#growth-playbook)
 - [Templates](#templates)
 - [Quality Bar](#quality-bar)
 - [Sources And Caveats](#sources-and-caveats)
@@ -296,6 +304,10 @@ The short version: write one measurable goal, point at the real context, add har
 ## Catalog Health
 
 The generated [catalog health report](docs/catalog-health.md) tracks source-backed coverage, source types, and search evaluation results.
+
+## Growth Playbook
+
+Use [docs/growth-playbook.md](docs/growth-playbook.md) to plan one-week contributor and traffic measurement. It separates leading signals such as catalog traffic, search eval health, and merged PRs from lagging indicators such as stars.
 
 ## Templates
 

--- a/docs/growth-playbook.md
+++ b/docs/growth-playbook.md
@@ -1,0 +1,40 @@
+# Growth Playbook
+
+Use this as a one-week measurement plan for making awesome-goal-prompts easier to discover and contribute to. External outcomes are tracked, not guaranteed.
+
+## Target Audiences
+
+- Coding-agent users who need rescue contracts when an agent drifts, loops, or weakens verification.
+- Maintainers who want source-backed examples for common repo tasks, CI failures, migrations, and security reviews.
+- Contributors who can turn public docs, GitHub issues, forum threads, or tool READMEs into verifiable `/goal` catalog entries.
+
+## Shareable Entry Points
+
+| Entry point | What to share | Success signal |
+| --- | --- | --- |
+| Rescue prompts | `README.md` "Start With Ten Rescue Prompts" and `prompts/source-backed-goals.md` | Visitors copy a prompt or open a static goal page. |
+| make-goal skill | `skills/make-goal/` plus `skills/make-goal/references/catalog-contribution.md` | Contributors submit source-backed entries with provenance fields. |
+| Catalog search | https://majiayu000.github.io/awesome-goal-prompts/ | Search queries retrieve expected entries and users browse source-backed examples first. |
+
+## One-Week Measurement
+
+| Signal | Type | How to measure | Week-one target |
+| --- | --- | --- | --- |
+| GitHub Pages visits and referrers | Leading | GitHub repository traffic and Pages analytics if available | Directional increase after sharing; no fixed traffic guarantee. |
+| Catalog search health | Leading | `python3 scripts/evaluate_search.py` | All eval cases pass after catalog changes. |
+| Source-backed coverage | Leading | `python3 scripts/generate_catalog_health.py` and `docs/catalog-health.md` | Source-backed count rises without missing provenance fields. |
+| Contributor PRs merged | Leading | GitHub PR list for source-backed entries or docs improvements | At least one reviewed PR path is clear and reproducible. |
+| README contribution clicks | Leading | GitHub traffic for `CONTRIBUTING.md`, `docs/how-to-write-goals.md`, and `skills/make-goal/` | More views than baseline if GitHub exposes file traffic. |
+| Stars | Lagging | GitHub repository stars | Track trend only; do not use as a completion criterion. |
+
+## Manual Repo Settings Checklist
+
+- Add or review repository topics such as `codex`, `claude-code`, `cursor`, `coding-agents`, `prompts`, and `goal`.
+- Set a social preview image that shows the searchable catalog, not only the README title.
+- Consider enabling GitHub Discussions for source suggestions and duplicate checks.
+- Draft an awesome-list submission only after the source-backed catalog and contribution path are stable.
+- Prepare social hooks around rescue prompts, the make-goal skill, and catalog search; do not promise stars, trending, ranking, or approval.
+
+## Review Cadence
+
+After one week, compare leading signals to the baseline, inspect failed or low-rank search queries, and choose the next smallest PR: more thin-category entries, a Chinese README slice, or additional search eval cases.


### PR DESCRIPTION
## Summary
- Add a short growth playbook for one-week contributor and traffic measurement.
- Add README entry points for contributing a goal and finding the growth playbook.
- Keep stars as a lagging metric, not a completion criterion.

## Verification
- python3 scripts/validate_data.py
- python3 scripts/generate_examples.py
- python3 scripts/validate_static_contracts.py
- python3 scripts/generate_static_contracts.py --output docs/goals
- python3 scripts/generate_sitemap.py
- python3 scripts/validate_metadata.py
- python3 scripts/generate_catalog_health.py
- python3 scripts/evaluate_search.py
- python3 skills/make-goal/scripts/run_evals.py
- node --check docs/app.js
- git diff --check